### PR TITLE
feat: modern baseline UI with Tailwind and mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-﻿# Student Mgmt App (Baseline)
-See README in bash section above.
+# Student Mgmt App
+
+Modernized administrative dashboard powered by Flask (backend) and a static Tailwind/Alpine front-end.
+
+## Getting started
+
+1. Create and activate a virtual environment (optional but recommended).
+2. Install backend dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Seed MongoDB with baseline data (requires a running Mongo instance and valid credentials):
+   ```bash
+   python scripts/seed.py
+   ```
+4. Set the `MONGODB_URI` environment variable for the Flask app (defaults to `mongodb://localhost:27017/student_mgmt`). Example:
+   ```bash
+   export MONGODB_URI="mongodb://localhost:27017/student_mgmt"
+   ```
+5. Start the development server:
+   ```bash
+   python backend/app.py
+   ```
+6. Visit [http://localhost:5000](http://localhost:5000) to explore the dashboard and feature pages.
+
+> **Tip:** The front-end currently uses in-browser mock data to demonstrate interactions. Once the API endpoints are wired up, the same UI will consume live data.

--- a/frontend/assets/logo.svg
+++ b/frontend/assets/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Student Mgmt logo">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="url(#grad)" />
+  <path d="M20 26h24M20 34h24M20 42h12" stroke="#e2e8f0" stroke-width="4" stroke-linecap="round" />
+  <circle cx="44" cy="42" r="6" fill="#f97316" />
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,310 @@
-﻿<!DOCTYPE html><html lang="vi"><head>
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Student Mgmt — Baseline</title>
-<script src="https://cdn.tailwindcss.com"></script>
-<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head><body class="min-h-screen bg-slate-50">
-<div class="max-w-3xl mx-auto p-6 space-y-4">
-  <h1 class="text-2xl font-bold">Baseline Ready ✅</h1>
-  <p>Backend: Flask at <code>/api/health</code> • Frontend: Tailwind + Alpine + Chart.js</p>
-  <a class="inline-block px-4 py-2 rounded-xl bg-black text-white" href="/pages/students.html">Go to Students</a>
-</div>
-</body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Student Management Dashboard</title>
+  <link rel="stylesheet" href="/style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="/assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Academic year <span class="font-semibold text-slate-700">2025</span></p>
+        <p class="mt-1">Updated <span class="font-semibold text-slate-700">today</span></p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Dashboard</p>
+              <h1 class="text-lg font-semibold text-slate-900">Welcome back, team</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="text-slate-900">Overview</a>
+            <a href="/pages/students.html" class="hover:text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="dashboardPage()">
+          <section class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Academic snapshot</h2>
+              <p class="mt-2 text-slate-600">Track enrollment, retention, and performance metrics for the current academic cycle.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <a href="/pages/students.html" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                Add student
+              </a>
+              <a href="/pages/courses.html" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                Manage catalog
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M9 5.25 15.75 12 9 18.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+              </a>
+            </div>
+          </section>
+
+          <section class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+            <template x-for="card in cards" :key="card.name">
+              <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                <div class="flex items-center justify-between">
+                  <div>
+                    <p class="text-xs uppercase tracking-wide text-slate-400" x-text="card.name"></p>
+                    <p class="mt-2 text-3xl font-semibold text-slate-900" x-text="card.value"></p>
+                  </div>
+                  <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900/10 text-slate-700">
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12.75 9 17.25 19.5 6.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                  </span>
+                </div>
+                <p class="mt-3 text-xs font-medium text-emerald-600" x-text="card.delta"></p>
+              </article>
+            </template>
+          </section>
+
+          <section class="mt-10 grid gap-6 lg:grid-cols-5">
+            <article class="lg:col-span-3 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <header class="flex items-center justify-between">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-900">Students by major</h3>
+                  <p class="text-sm text-slate-500">Current headcount across departments</p>
+                </div>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Updated weekly</span>
+              </header>
+              <div class="mt-6"><canvas id="majorChart" aria-label="Bar chart showing students by major" role="img"></canvas></div>
+            </article>
+            <article class="lg:col-span-2 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <header class="flex items-center justify-between">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-900">Enrollments per semester</h3>
+                  <p class="text-sm text-slate-500">Multi-term trend, including summer sessions</p>
+                </div>
+                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">Rolling 4 terms</span>
+              </header>
+              <div class="mt-6"><canvas id="enrollmentChart" aria-label="Line chart showing enrollments per semester" role="img"></canvas></div>
+            </article>
+          </section>
+
+          <section class="mt-10 grid gap-6 lg:grid-cols-3">
+            <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-2">
+              <h3 class="text-lg font-semibold text-slate-900">Advising checklist</h3>
+              <ul class="mt-4 space-y-3 text-sm">
+                <template x-for="item in checklist" :key="item.title">
+                  <li class="flex items-start gap-3 rounded-xl border border-slate-100 bg-slate-50/60 px-4 py-3">
+                    <span class="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white" x-text="item.step"></span>
+                    <div>
+                      <p class="font-medium text-slate-800" x-text="item.title"></p>
+                      <p class="text-slate-500" x-text="item.description"></p>
+                    </div>
+                  </li>
+                </template>
+              </ul>
+            </article>
+            <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h3 class="text-lg font-semibold text-slate-900">Quick links</h3>
+              <ul class="mt-4 space-y-3 text-sm">
+                <template x-for="link in quickLinks" :key="link.href">
+                  <li>
+                    <a :href="link.href" class="group flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:bg-slate-50">
+                      <div>
+                        <p class="font-medium text-slate-800" x-text="link.title"></p>
+                        <p class="text-xs text-slate-500" x-text="link.description"></p>
+                      </div>
+                      <svg class="h-4 w-4 text-slate-400 transition group-hover:text-slate-900" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5.25 15.75 12 9 18.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                    </a>
+                  </li>
+                </template>
+              </ul>
+            </article>
+          </section>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const dashboardMock = {
+      students: [
+        { id: 'S-1001', name: 'Asha Patel', major: 'Computer Science' },
+        { id: 'S-1002', name: 'Ethan Wright', major: 'Mathematics' },
+        { id: 'S-1003', name: 'Lina Alvarez', major: 'Biology' },
+        { id: 'S-1004', name: 'Noah Kim', major: 'Computer Science' },
+        { id: 'S-1005', name: 'Maya Chen', major: 'Economics' },
+        { id: 'S-1006', name: 'Gabriel Souza', major: 'Physics' },
+        { id: 'S-1007', name: 'Leah Johnson', major: 'Computer Science' },
+        { id: 'S-1008', name: 'Omar Ali', major: 'Economics' }
+      ],
+      courses: [
+        { id: 'CIS-210', title: 'Data Structures' },
+        { id: 'BIO-120', title: 'Genetics' },
+        { id: 'MTH-240', title: 'Linear Algebra' },
+        { id: 'ECO-201', title: 'Microeconomics' },
+        { id: 'PHY-330', title: 'Quantum Mechanics' },
+        { id: 'CIS-330', title: 'Operating Systems' }
+      ],
+      sections: [
+        { id: 'SEC-101', capacity: 32 },
+        { id: 'SEC-102', capacity: 28 },
+        { id: 'SEC-103', capacity: 24 },
+        { id: 'SEC-104', capacity: 26 },
+        { id: 'SEC-105', capacity: 22 },
+        { id: 'SEC-106', capacity: 18 }
+      ],
+      enrollments: [
+        { semester: '2024 Fall', count: 310 },
+        { semester: '2025 Spring', count: 298 },
+        { semester: '2025 Summer', count: 184 },
+        { semester: '2025 Fall', count: 327 }
+      ]
+    };
+
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('dashboardPage', () => ({
+        cards: [
+          { name: 'Total students', value: dashboardMock.students.length, delta: '+12% vs LY' },
+          { name: 'Active courses', value: dashboardMock.courses.length, delta: '+3 new this term' },
+          { name: 'Sections this term', value: dashboardMock.sections.length, delta: '92% capacity filled' },
+          { name: 'Enrollments', value: dashboardMock.enrollments.reduce((sum, entry) => sum + entry.count, 0), delta: '+18 since last week' }
+        ],
+        checklist: [
+          { step: 1, title: 'Confirm advising rosters', description: 'Finalize assignments for new transfer students.' },
+          { step: 2, title: 'Publish midterm grades', description: 'Grades are due Friday at 5pm for 200-level courses.' },
+          { step: 3, title: 'Audit waitlists', description: 'Sections exceeding 95% capacity require approval.' }
+        ],
+        quickLinks: [
+          { title: 'Review student directory', description: 'Search and manage profiles.', href: '/pages/students.html' },
+          { title: 'Update course catalog', description: 'Edit credit hours & descriptions.', href: '/pages/courses.html' },
+          { title: 'Coordinate sections', description: 'Assign rooms and instructors.', href: '/pages/sections.html' }
+        ]
+      }));
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const majorCounts = dashboardMock.students.reduce((acc, student) => {
+        acc[student.major] = (acc[student.major] || 0) + 1;
+        return acc;
+      }, {});
+      const majors = Object.keys(majorCounts);
+      const majorValues = majors.map((major) => majorCounts[major]);
+
+      const enrollmentsBySemester = dashboardMock.enrollments;
+
+      const barCtx = document.getElementById('majorChart');
+      if (barCtx) {
+        new Chart(barCtx, {
+          type: 'bar',
+          data: {
+            labels: majors,
+            datasets: [
+              {
+                label: 'Students',
+                data: majorValues,
+                backgroundColor: '#1e293b'
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false }
+            },
+            scales: {
+              x: { ticks: { color: '#475569' } },
+              y: { ticks: { color: '#475569' }, beginAtZero: true, suggestedMax: Math.max(...majorValues, 5) + 2 }
+            }
+          }
+        });
+      }
+
+      const lineCtx = document.getElementById('enrollmentChart');
+      if (lineCtx) {
+        new Chart(lineCtx, {
+          type: 'line',
+          data: {
+            labels: enrollmentsBySemester.map((item) => item.semester),
+            datasets: [
+              {
+                label: 'Enrollments',
+                data: enrollmentsBySemester.map((item) => item.count),
+                fill: false,
+                borderColor: '#0f172a',
+                backgroundColor: '#0f172a',
+                tension: 0.4,
+                pointRadius: 4,
+                pointBackgroundColor: '#f97316'
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false }
+            },
+            scales: {
+              x: { ticks: { color: '#475569' } },
+              y: { ticks: { color: '#475569' }, beginAtZero: false }
+            }
+          }
+        });
+      }
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/courses.html
+++ b/frontend/pages/courses.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Courses · Student Mgmt</title>
+  <link rel="stylesheet" href="../style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="../assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Catalog last synced <span class="font-semibold text-slate-700">3 mins ago</span></p>
+        <p class="mt-1">Dean review <span class="font-semibold text-slate-700">Apr 15</span></p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Catalog</p>
+              <h1 class="text-lg font-semibold text-slate-900">Courses</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="hover:text-slate-900">Dashboard</a>
+            <a href="/pages/students.html" class="hover:text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="coursesPage()">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Course catalog</h2>
+              <p class="mt-2 text-slate-600">Browse and curate the academic catalog students can enroll in next term.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <button type="button" @click="openModal()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                Add course
+              </button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 4.5h15v15h-15z" /><path d="M7.5 7.5h9v9h-9z" /><path d="M7.5 12h9" /></svg>
+                Print summary
+              </button>
+            </div>
+          </div>
+
+          <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div class="w-full md:max-w-sm">
+                <label for="course-search" class="text-sm font-medium text-slate-700">Search courses</label>
+                <div class="mt-1 relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="6" /><path d="m17 17 3.5 3.5" stroke-linecap="round" /></svg>
+                  </span>
+                  <input id="course-search" type="search" x-model="search" placeholder="Find by title, code, or dept" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
+                </div>
+              </div>
+              <div class="flex flex-col gap-4 sm:flex-row">
+                <div>
+                  <label for="dept-filter" class="text-sm font-medium text-slate-700">Department</label>
+                  <select id="dept-filter" x-model="selectedDept" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
+                    <option value="">All departments</option>
+                    <template x-for="dept in departments" :key="dept.id">
+                      <option :value="dept.id" x-text="`${dept.name} (${dept.id})`"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label for="credits-filter" class="text-sm font-medium text-slate-700">Credits</label>
+                  <select id="credits-filter" x-model="selectedCredits" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
+                    <option value="">All</option>
+                    <option value="3">3 credits</option>
+                    <option value="4">4 credits</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-8 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+              <template x-if="filteredCourses.length === 0">
+                <div class="sm:col-span-2 xl:col-span-3 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                  <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                    <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
+                  </span>
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-900">No courses found</h3>
+                    <p class="mt-1 text-sm text-slate-500">Adjust filters or add a new course to the catalog.</p>
+                  </div>
+                  <button type="button" @click="openModal()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                    Add course
+                  </button>
+                </div>
+              </template>
+
+              <template x-for="course in filteredCourses" :key="course.id">
+                <article class="flex flex-col justify-between rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                  <div class="space-y-3">
+                    <div class="flex items-center justify-between">
+                      <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                        <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                        <span x-text="course.dept_id"></span>
+                      </span>
+                      <span class="text-xs font-semibold text-slate-400" x-text="`${course.credits} credits`"></span>
+                    </div>
+                    <div>
+                      <h3 class="text-lg font-semibold text-slate-900" x-text="course.title"></h3>
+                      <p class="text-sm text-slate-500" x-text="course.description"></p>
+                    </div>
+                  </div>
+                  <div class="mt-6 flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
+                    <p class="font-medium text-slate-700" x-text="course.id"></p>
+                    <div class="flex items-center gap-2">
+                      <button type="button" @click="openModal(course)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
+                        Edit
+                      </button>
+                      <button type="button" @click="removeCourse(course.id)" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50">
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              </template>
+            </div>
+          </section>
+        </div>
+
+        <div x-cloak x-show="toast.visible" x-transition class="fixed top-4 right-4 z-50 w-full max-w-sm rounded-xl border px-4 py-3 shadow-lg" :class="toast.variant === 'success' ? 'border-emerald-200 bg-emerald-50/90 text-emerald-800' : 'border-rose-200 bg-rose-50/90 text-rose-700'" role="status" aria-live="polite">
+          <div class="flex items-start gap-3">
+            <span class="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full" :class="toast.variant === 'success' ? 'bg-emerald-600 text-white' : 'bg-rose-600 text-white'">
+              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><template x-if="toast.variant === 'success'"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></template><template x-if="toast.variant !== 'success'"><path d="M15 9 9 15m0-6 6 6" stroke-linecap="round" stroke-linejoin="round" /></template></svg>
+            </span>
+            <div>
+              <p class="text-sm font-semibold" x-text="toast.message"></p>
+              <p class="text-xs text-slate-500" x-text="toast.detail"></p>
+            </div>
+            <button type="button" class="ml-auto text-xs font-medium text-slate-500 hover:text-slate-700" @click="toast.visible = false">Dismiss</button>
+          </div>
+        </div>
+
+        <div x-cloak x-show="modalOpen" class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6" role="dialog" aria-modal="true">
+          <div class="absolute inset-0 bg-slate-900/40" @click="closeModal()"></div>
+          <div class="relative w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-xl" x-trap.noscroll="modalOpen" x-transition>
+            <header class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-xs uppercase tracking-widest text-slate-400" x-text="editingCourse ? 'Update course' : 'Create course'"></p>
+                <h2 class="text-2xl font-semibold text-slate-900" x-text="editingCourse ? 'Edit course' : 'Add new course'"></h2>
+              </div>
+              <button type="button" class="rounded-lg border border-transparent p-2 text-slate-400 hover:text-slate-600" @click="closeModal()" aria-label="Close dialog">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 9l6 6m0-6-6 6" stroke-linecap="round" /></svg>
+              </button>
+            </header>
+            <form class="mt-6 space-y-4" @submit.prevent="saveCourse()">
+              <div>
+                <label for="course-id" class="text-sm font-medium text-slate-700">Course code</label>
+                <input id="course-id" type="text" x-model="form.id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. CIS-210" required />
+                <p class="mt-1 text-xs text-slate-500">Use the registrar approved catalog code.</p>
+                <p x-show="errors.id" x-text="errors.id" class="mt-1 text-xs font-medium text-rose-600"></p>
+              </div>
+              <div>
+                <label for="course-title" class="text-sm font-medium text-slate-700">Title</label>
+                <input id="course-title" type="text" x-model="form.title" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.title ? 'border-rose-300' : 'border-slate-200'" placeholder="Course title" required />
+                <p x-show="errors.title" x-text="errors.title" class="mt-1 text-xs font-medium text-rose-600"></p>
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label for="course-dept" class="text-sm font-medium text-slate-700">Department</label>
+                  <select id="course-dept" x-model="form.dept_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.dept_id ? 'border-rose-300' : 'border-slate-200'" required>
+                    <option value="" disabled>Select department</option>
+                    <template x-for="dept in departments" :key="dept.id">
+                      <option :value="dept.id" x-text="`${dept.name} (${dept.id})`"></option>
+                    </template>
+                  </select>
+                  <p x-show="errors.dept_id" x-text="errors.dept_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+                </div>
+                <div>
+                  <label for="course-credits" class="text-sm font-medium text-slate-700">Credits</label>
+                  <input id="course-credits" type="number" min="0" step="1" x-model.number="form.credits" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.credits ? 'border-rose-300' : 'border-slate-200'" placeholder="3" required />
+                  <p x-show="errors.credits" x-text="errors.credits" class="mt-1 text-xs font-medium text-rose-600"></p>
+                </div>
+              </div>
+              <div>
+                <label for="course-description" class="text-sm font-medium text-slate-700">Description</label>
+                <textarea id="course-description" rows="3" x-model="form.description" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="Brief summary of the course"></textarea>
+              </div>
+              <div class="flex items-center justify-end gap-3 pt-4">
+                <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300" @click="closeModal()">Cancel</button>
+                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                  Save course
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const courseSeed = [
+      { id: 'CIS-210', title: 'Data Structures', credits: 3, dept_id: 'CS', description: 'Foundational algorithms and data abstractions with weekly labs.' },
+      { id: 'CIS-330', title: 'Operating Systems', credits: 4, dept_id: 'CS', description: 'Kernel architecture, scheduling, and concurrency design.' },
+      { id: 'MTH-240', title: 'Linear Algebra', credits: 3, dept_id: 'MATH', description: 'Vector spaces, eigenvalues, and applications to data science.' },
+      { id: 'BIO-120', title: 'Genetics', credits: 4, dept_id: 'BIO', description: 'Fundamentals of DNA replication, transcription, and expression.' },
+      { id: 'ECON-201', title: 'Microeconomics', credits: 3, dept_id: 'ECON', description: 'Consumer theory, firm behavior, and market equilibrium.' },
+      { id: 'PHYS-330', title: 'Quantum Mechanics', credits: 4, dept_id: 'PHYS', description: 'Quantum theory of matter with emphasis on atomic systems.' }
+    ];
+
+    const courseDepartments = [
+      { id: 'CS', name: 'Computer Science' },
+      { id: 'MATH', name: 'Mathematics' },
+      { id: 'BIO', name: 'Biology' },
+      { id: 'PHYS', name: 'Physics' },
+      { id: 'ECON', name: 'Economics' },
+      { id: 'BUS', name: 'Business Administration' }
+    ];
+
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('coursesPage', () => ({
+        search: '',
+        selectedDept: '',
+        selectedCredits: '',
+        courses: courseSeed.map((course) => ({ ...course })),
+        departments: courseDepartments,
+        modalOpen: false,
+        editingCourse: null,
+        form: { id: '', title: '', credits: 3, dept_id: '', description: '' },
+        errors: {},
+        toast: { visible: false, message: '', detail: '', variant: 'success' },
+        get filteredCourses() {
+          return this.courses.filter((course) => {
+            const matchesDept = this.selectedDept ? course.dept_id === this.selectedDept : true;
+            const matchesCredits = this.selectedCredits ? Number(course.credits) === Number(this.selectedCredits) : true;
+            const term = this.search.trim().toLowerCase();
+            const matchesSearch = term
+              ? [course.title, course.id, course.dept_id].some((value) => (value || '').toLowerCase().includes(term))
+              : true;
+            return matchesDept && matchesCredits && matchesSearch;
+          });
+        },
+        openModal(course = null) {
+          this.editingCourse = course ? { ...course } : null;
+          this.form = course ? { ...course } : { id: '', title: '', credits: 3, dept_id: '', description: '' };
+          this.errors = {};
+          this.modalOpen = true;
+        },
+        closeModal() {
+          this.modalOpen = false;
+        },
+        validate() {
+          const nextErrors = {};
+          if (!this.form.id.trim()) nextErrors.id = 'Course code is required.';
+          if (!this.form.title.trim()) nextErrors.title = 'Course title is required.';
+          if (!this.form.dept_id) nextErrors.dept_id = 'Select a department.';
+          if (this.form.credits === '' || Number.isNaN(Number(this.form.credits)) || Number(this.form.credits) <= 0) {
+            nextErrors.credits = 'Credits must be a positive number.';
+          }
+          this.errors = nextErrors;
+          return Object.keys(nextErrors).length === 0;
+        },
+        saveCourse() {
+          if (!this.validate()) {
+            this.showToast('Please review the highlighted fields.', 'error', 'Invalid course details');
+            return;
+          }
+          if (this.editingCourse) {
+            const index = this.courses.findIndex((course) => course.id === this.editingCourse.id);
+            if (index !== -1) {
+              this.courses.splice(index, 1, { ...this.form });
+              this.showToast('Course updated successfully.', 'success', 'Catalog entry saved.');
+            }
+          } else {
+            if (this.courses.some((course) => course.id === this.form.id)) {
+              this.errors.id = 'A course with this code already exists.';
+              this.showToast('Duplicate course code.', 'error', 'Use a unique catalog code.');
+              return;
+            }
+            this.courses = [...this.courses, { ...this.form }];
+            this.showToast('Course added to catalog.', 'success', 'Publish changes when ready.');
+          }
+          this.closeModal();
+        },
+        removeCourse(id) {
+          if (!window.confirm('Remove this course from the catalog?')) {
+            return;
+          }
+          this.courses = this.courses.filter((course) => course.id !== id);
+          this.showToast('Course removed.', 'success', 'Students will no longer see this course.');
+        },
+        showToast(message, variant = 'success', detail = '') {
+          this.toast = { visible: true, message, variant, detail };
+          setTimeout(() => {
+            this.toast.visible = false;
+          }, 3200);
+        }
+      }));
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/enrollments.html
+++ b/frontend/pages/enrollments.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Enrollments · Student Mgmt</title>
+  <link rel="stylesheet" href="../style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="../assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Grade submission window <span class="font-semibold text-slate-700">May 8</span></p>
+        <p class="mt-1">Incomplete alerts <span class="font-semibold text-slate-700">2</span></p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Records</p>
+              <h1 class="text-lg font-semibold text-slate-900">Enrollments</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="hover:text-slate-900">Dashboard</a>
+            <a href="/pages/students.html" class="hover:text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="text-slate-900">Enrollments</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="enrollmentsPage()">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Enrollment ledger</h2>
+              <p class="mt-2 text-slate-600">Monitor performance, identify grade risks, and manage grading deadlines.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12" stroke-linecap="round" /><path d="M6 12h12" stroke-linecap="round" /></svg>
+                Create report
+              </button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5.25 15.75 12 9 18.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                Export grades
+              </button>
+            </div>
+          </div>
+
+          <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div class="w-full md:max-w-sm">
+                <label for="enrollment-search" class="text-sm font-medium text-slate-700">Search enrollments</label>
+                <div class="mt-1 relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="6" /><path d="m17 17 3.5 3.5" stroke-linecap="round" /></svg>
+                  </span>
+                  <input id="enrollment-search" type="search" x-model="search" placeholder="Search by student, section, or instructor" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
+                </div>
+              </div>
+              <div class="flex flex-col gap-4 sm:flex-row">
+                <div>
+                  <label for="semester-filter" class="text-sm font-medium text-slate-700">Semester</label>
+                  <select id="semester-filter" x-model="selectedSemester" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
+                    <option value="">All semesters</option>
+                    <template x-for="semester in semesters" :key="semester">
+                      <option x-text="semester"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label for="letter-filter" class="text-sm font-medium text-slate-700">Letter grade</label>
+                  <select id="letter-filter" x-model="selectedLetter" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
+                    <option value="">All</option>
+                    <template x-for="letter in letters" :key="letter">
+                      <option x-text="letter"></option>
+                    </template>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-xs text-slate-500">
+              <div class="flex items-center gap-2">
+                <input id="bulk-select" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-300" disabled />
+                <label for="bulk-select" class="font-medium text-slate-500">Bulk select (coming soon)</label>
+              </div>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-400" disabled>
+                <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 16.5h15" stroke-linecap="round" /><path d="M4.5 7.5h15" stroke-linecap="round" /></svg>
+                Apply bulk actions
+              </button>
+            </div>
+
+            <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                  <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                    <tr>
+                      <th scope="col" class="px-4 py-3 font-semibold">Student</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Midterm</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Final</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Bonus</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Letter</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100 bg-white">
+                    <template x-for="record in filteredEnrollments" :key="record.id">
+                      <tr class="hover:bg-slate-50">
+                        <td class="px-4 py-3">
+                          <div class="font-medium text-slate-900" x-text="record.student_name"></div>
+                          <p class="text-xs text-slate-500" x-text="record.student_id"></p>
+                        </td>
+                        <td class="px-4 py-3">
+                          <div class="font-medium text-slate-900" x-text="record.section"></div>
+                          <p class="text-xs text-slate-500" x-text="record.course"></p>
+                        </td>
+                        <td class="px-4 py-3">
+                          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                            <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                            <span x-text="record.semester"></span>
+                          </span>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.midterm"></td>
+                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.final"></td>
+                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.bonus"></td>
+                        <td class="px-4 py-3">
+                          <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" :class="badgeClass(record.letter)">
+                            <span x-text="record.letter"></span>
+                            <span class="hidden sm:inline" x-text="record.status"></span>
+                          </span>
+                        </td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <template x-if="filteredEnrollments.length === 0">
+              <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                  <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+                </span>
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-900">No enrollment records</h3>
+                  <p class="mt-1 text-sm text-slate-500">Broaden your filters or refresh after instructors submit grades.</p>
+                </div>
+              </div>
+            </template>
+          </section>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const enrollmentSeed = [
+      { id: 'ENR-1', student_id: 'S-1001', student_name: 'Asha Patel', section: 'SEC-101', course: 'Data Structures', semester: '2025 Spring', midterm: 88, final: 93, bonus: 5, letter: 'A', status: 'Honors' },
+      { id: 'ENR-2', student_id: 'S-1002', student_name: 'Ethan Wright', section: 'SEC-103', course: 'Linear Algebra', semester: '2025 Spring', midterm: 76, final: 82, bonus: 2, letter: 'B', status: 'Passing' },
+      { id: 'ENR-3', student_id: 'S-1003', student_name: 'Lina Alvarez', section: 'SEC-104', course: 'Genetics', semester: '2025 Summer', midterm: 91, final: 89, bonus: 4, letter: 'A-', status: 'Dean list' },
+      { id: 'ENR-4', student_id: 'S-1004', student_name: 'Noah Kim', section: 'SEC-102', course: 'Operating Systems', semester: '2025 Spring', midterm: 68, final: 75, bonus: 3, letter: 'B-', status: 'Coaching' },
+      { id: 'ENR-5', student_id: 'S-1005', student_name: 'Maya Chen', section: 'SEC-105', course: 'Microeconomics', semester: '2025 Fall', midterm: 95, final: 97, bonus: 4, letter: 'A', status: 'Honors' },
+      { id: 'ENR-6', student_id: 'S-1006', student_name: 'Gabriel Souza', section: 'SEC-106', course: 'Quantum Mechanics', semester: '2025 Fall', midterm: 84, final: 80, bonus: 1, letter: 'B', status: 'Passing' },
+      { id: 'ENR-7', student_id: 'S-1007', student_name: 'Leah Johnson', section: 'SEC-101', course: 'Data Structures', semester: '2025 Spring', midterm: 92, final: 94, bonus: 3, letter: 'A', status: 'Honors' },
+      { id: 'ENR-8', student_id: 'S-1008', student_name: 'Omar Ali', section: 'SEC-105', course: 'Microeconomics', semester: '2025 Fall', midterm: 71, final: 78, bonus: 2, letter: 'B-', status: 'Coaching' },
+      { id: 'ENR-9', student_id: 'S-1009', student_name: 'Jules Laurent', section: 'SEC-107', course: 'Managerial Finance', semester: '2025 Fall', midterm: 66, final: 70, bonus: 0, letter: 'C+', status: 'Watch' },
+      { id: 'ENR-10', student_id: 'S-1010', student_name: 'Sara Ito', section: 'SEC-104', course: 'Genetics', semester: '2025 Summer', midterm: 89, final: 88, bonus: 2, letter: 'A-', status: 'Dean list' }
+    ];
+
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('enrollmentsPage', () => ({
+        enrollments: enrollmentSeed.map((record) => ({ ...record })),
+        search: '',
+        selectedSemester: '',
+        selectedLetter: '',
+        get semesters() {
+          return [...new Set(this.enrollments.map((record) => record.semester))];
+        },
+        get letters() {
+          return [...new Set(this.enrollments.map((record) => record.letter))];
+        },
+        get filteredEnrollments() {
+          const term = this.search.trim().toLowerCase();
+          return this.enrollments.filter((record) => {
+            const matchesSemester = this.selectedSemester ? record.semester === this.selectedSemester : true;
+            const matchesLetter = this.selectedLetter ? record.letter === this.selectedLetter : true;
+            const matchesSearch = term
+              ? [record.student_name, record.student_id, record.section, record.course].some((value) =>
+                  (value || '').toLowerCase().includes(term)
+                )
+              : true;
+            return matchesSemester && matchesLetter && matchesSearch;
+          });
+        },
+        badgeClass(letter) {
+          const palette = {
+            A: 'bg-emerald-100 text-emerald-700',
+            'A-': 'bg-emerald-50 text-emerald-700',
+            B: 'bg-sky-100 text-sky-700',
+            'B-': 'bg-sky-50 text-sky-700',
+            'C+': 'bg-amber-100 text-amber-800'
+          };
+          return palette[letter] || 'bg-slate-100 text-slate-700';
+        }
+      }));
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/sections.html
+++ b/frontend/pages/sections.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sections · Student Mgmt</title>
+  <link rel="stylesheet" href="../style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="../assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Room audit <span class="font-semibold text-slate-700">due May 3</span></p>
+        <p class="mt-1">Seats available <span class="font-semibold text-slate-700">148</span></p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Scheduling</p>
+              <h1 class="text-lg font-semibold text-slate-900">Sections</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="hover:text-slate-900">Dashboard</a>
+            <a href="/pages/students.html" class="hover:text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="sectionsPage()">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Class sections</h2>
+              <p class="mt-2 text-slate-600">Coordinate offerings across semesters, instructors, and available rooms.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 7.5h13.5" stroke-linecap="round" /><path d="M5.25 12h13.5" stroke-linecap="round" /><path d="M5.25 16.5h13.5" stroke-linecap="round" /></svg>
+                Export plan
+              </button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                New section
+              </button>
+            </div>
+          </div>
+
+          <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div class="grid gap-4 md:grid-cols-3">
+              <div class="md:col-span-2">
+                <label for="section-search" class="text-sm font-medium text-slate-700">Search sections</label>
+                <div class="mt-1 relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="6" /><path d="m17 17 3.5 3.5" stroke-linecap="round" /></svg>
+                  </span>
+                  <input id="section-search" type="search" x-model="search" placeholder="Search by course, instructor, or room" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
+                </div>
+              </div>
+              <div>
+                <label for="semester-filter" class="text-sm font-medium text-slate-700">Semester</label>
+                <select id="semester-filter" x-model="selectedSemester" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
+                  <option value="">All semesters</option>
+                  <template x-for="semester in semesters" :key="semester">
+                    <option x-text="semester"></option>
+                  </template>
+                </select>
+              </div>
+            </div>
+
+            <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                  <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                    <tr>
+                      <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Course</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Instructor</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Capacity</th>
+                      <th scope="col" class="px-4 py-3 font-semibold">Room</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100 bg-white">
+                    <template x-for="section in filteredSections" :key="section.id">
+                      <tr class="hover:bg-slate-50">
+                        <td class="px-4 py-3 font-mono text-xs text-slate-500" x-text="section.id"></td>
+                        <td class="px-4 py-3">
+                          <div class="font-medium text-slate-900" x-text="section.course_title"></div>
+                          <p class="text-xs text-slate-500" x-text="section.course_id"></p>
+                        </td>
+                        <td class="px-4 py-3">
+                          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                            <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                            <span x-text="section.semester"></span>
+                          </span>
+                        </td>
+                        <td class="px-4 py-3">
+                          <span class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm">
+                            <svg class="h-3.5 w-3.5 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+                            <span x-text="section.instructor"></span>
+                          </span>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-slate-700">
+                          <div class="font-semibold" x-text="`${section.enrolled}/${section.capacity}`"></div>
+                          <p class="text-xs text-slate-500" x-text="section.waitlist ? `${section.waitlist} waitlisted` : 'No waitlist'"></p>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-slate-700" x-text="section.room"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <template x-if="filteredSections.length === 0">
+              <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                  <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
+                </span>
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-900">No sections scheduled</h3>
+                  <p class="mt-1 text-sm text-slate-500">Adjust search filters or create a new section to fill the gap.</p>
+                </div>
+              </div>
+            </template>
+          </section>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const sectionSeed = [
+      { id: 'SEC-101', course_id: 'CIS-210', course_title: 'Data Structures', semester: '2025 Spring', instructor: 'Dr. Maya Li', capacity: 32, enrolled: 29, waitlist: 2, room: 'ENG 210' },
+      { id: 'SEC-102', course_id: 'CIS-330', course_title: 'Operating Systems', semester: '2025 Spring', instructor: 'Prof. Victor Tan', capacity: 28, enrolled: 27, waitlist: 0, room: 'CS 301' },
+      { id: 'SEC-103', course_id: 'MTH-240', course_title: 'Linear Algebra', semester: '2025 Spring', instructor: 'Dr. Ana Gomez', capacity: 30, enrolled: 30, waitlist: 4, room: 'SCI 112' },
+      { id: 'SEC-104', course_id: 'BIO-120', course_title: 'Genetics', semester: '2025 Summer', instructor: 'Dr. Leah Bennett', capacity: 24, enrolled: 20, waitlist: 0, room: 'BIO 220' },
+      { id: 'SEC-105', course_id: 'ECON-201', course_title: 'Microeconomics', semester: '2025 Fall', instructor: 'Dr. Omar Haddad', capacity: 40, enrolled: 36, waitlist: 3, room: 'BUS 105' },
+      { id: 'SEC-106', course_id: 'PHYS-330', course_title: 'Quantum Mechanics', semester: '2025 Fall', instructor: 'Prof. Helena Ruiz', capacity: 22, enrolled: 18, waitlist: 0, room: 'PHY 410' },
+      { id: 'SEC-107', course_id: 'BUS-210', course_title: 'Managerial Finance', semester: '2025 Fall', instructor: 'Dr. Daniel Ortiz', capacity: 35, enrolled: 31, waitlist: 1, room: 'BUS 204' }
+    ];
+
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('sectionsPage', () => ({
+        sections: sectionSeed.map((section) => ({ ...section })),
+        search: '',
+        selectedSemester: '',
+        get semesters() {
+          return [...new Set(this.sections.map((section) => section.semester))];
+        },
+        get filteredSections() {
+          const term = this.search.trim().toLowerCase();
+          return this.sections.filter((section) => {
+            const matchesSemester = this.selectedSemester ? section.semester === this.selectedSemester : true;
+            const matchesSearch = term
+              ? [section.course_title, section.course_id, section.instructor, section.room].some((value) =>
+                  (value || '').toLowerCase().includes(term)
+                )
+              : true;
+            return matchesSemester && matchesSearch;
+          });
+        }
+      }));
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/students.html
+++ b/frontend/pages/students.html
@@ -1,12 +1,423 @@
-﻿<!DOCTYPE html><html lang="vi"><head>
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Students</title>
-<script src="https://cdn.tailwindcss.com"></script>
-<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
-</head><body class="min-h-screen bg-slate-50">
-<div class="max-w-4xl mx-auto p-6">
-  <a href="/" class="text-slate-600 hover:text-black">← Back</a>
-  <h1 class="text-xl font-semibold mt-2">Students</h1>
-  <p class="text-slate-600 mt-2">Baseline page. We’ll wire real APIs next.</p>
-</div>
-</body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Students · Student Mgmt</title>
+  <link rel="stylesheet" href="../style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="../assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Academic year <span class="font-semibold text-slate-700">2025</span></p>
+        <p class="mt-1">Admissions freeze <span class="font-semibold text-slate-700">in 4 days</span></p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Directory</p>
+              <h1 class="text-lg font-semibold text-slate-900">Students</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="hover:text-slate-900">Dashboard</a>
+            <a href="/pages/students.html" class="text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="studentsPage()">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Student roster</h2>
+              <p class="mt-2 text-slate-600">Search, add, and manage student profiles for the current academic cycle.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                Add student
+              </button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M5.25 7.5h13.5" stroke-linecap="round" /><path d="M5.25 12h13.5" stroke-linecap="round" /><path d="M5.25 16.5h13.5" stroke-linecap="round" /></svg>
+                Export CSV
+              </button>
+            </div>
+          </div>
+
+          <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" aria-labelledby="student-search">
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div class="flex-1">
+                <label id="student-search" class="sr-only" for="search">Search students</label>
+                <div class="relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="11" cy="11" r="6" /><path d="m17 17 3.5 3.5" stroke-linecap="round" /></svg>
+                  </span>
+                  <input x-model="search" type="search" id="search" placeholder="Search by name, email, or ID" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
+                </div>
+                <p class="mt-2 text-xs text-slate-500">Type to filter students instantly. Search is case-insensitive.</p>
+              </div>
+              <div class="grid grid-cols-2 gap-3 text-xs text-slate-500 sm:flex sm:flex-col sm:text-right">
+                <div>
+                  <p class="font-semibold text-slate-900" x-text="students.length"></p>
+                  <p>Total students</p>
+                </div>
+                <div>
+                  <p class="font-semibold text-slate-900" x-text="classYears"></p>
+                  <p>Class years tracked</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="relative mt-6">
+              <template x-if="loading">
+                <div class="space-y-3">
+                  <template x-for="i in 5" :key="i">
+                    <div class="rounded-xl border border-slate-100 bg-slate-50/70 p-4">
+                      <div class="flex items-center justify-between">
+                        <div class="flex flex-col gap-2">
+                          <span class="skeleton-line h-4 w-40 rounded"></span>
+                          <span class="skeleton-line h-3 w-56 rounded"></span>
+                        </div>
+                        <span class="skeleton-line h-6 w-16 rounded"></span>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </template>
+
+              <template x-if="!loading && filteredStudents.length === 0">
+                <div class="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                  <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                    <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16.5 10.5a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z" /><path d="M8.25 15.75a6.75 6.75 0 0 0 7.5 0" stroke-linecap="round" /><path d="M5.25 5.25 3 7.5m18-2.25-2.25 2.25" stroke-linecap="round" /></svg>
+                  </span>
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-900">No students match your search</h3>
+                    <p class="mt-1 text-sm text-slate-500">Try adjusting your filters or add a new student to the roster.</p>
+                  </div>
+                  <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                    Add first student
+                  </button>
+                </div>
+              </template>
+
+              <div x-cloak x-show="!loading && filteredStudents.length" class="overflow-hidden rounded-2xl border border-slate-200">
+                <div class="overflow-x-auto">
+                  <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                    <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                      <tr>
+                        <th scope="col" class="px-4 py-3 font-semibold">ID</th>
+                        <th scope="col" class="px-4 py-3 font-semibold">Full name</th>
+                        <th scope="col" class="px-4 py-3 font-semibold">Email</th>
+                        <th scope="col" class="px-4 py-3 font-semibold">Major</th>
+                        <th scope="col" class="px-4 py-3 font-semibold">Year</th>
+                        <th scope="col" class="px-4 py-3 font-semibold text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                      <template x-for="student in filteredStudents" :key="student._id">
+                        <tr class="hover:bg-slate-50">
+                          <td class="px-4 py-3 font-mono text-xs text-slate-500" x-text="student._id"></td>
+                          <td class="px-4 py-3">
+                            <div class="font-medium text-slate-900" x-text="student.full_name"></div>
+                            <p class="text-xs text-slate-500" x-text="student.pronouns"></p>
+                          </td>
+                          <td class="px-4 py-3">
+                            <a :href="`mailto:${student.email}`" class="text-sm text-slate-700 hover:text-slate-900" x-text="student.email"></a>
+                          </td>
+                          <td class="px-4 py-3">
+                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                              <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                              <span x-text="departmentMap[student.major_dept_id] || student.major_dept_id"></span>
+                            </span>
+                          </td>
+                          <td class="px-4 py-3 text-sm text-slate-700" x-text="student.year"></td>
+                          <td class="px-4 py-3 text-right">
+                            <div class="inline-flex items-center gap-2">
+                              <button type="button" @click="openEdit(student)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
+                                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
+                                Edit
+                              </button>
+                              <button type="button" @click="deleteStudent(student._id)" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50">
+                                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
+                                Delete
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      </template>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div x-cloak x-show="toast.visible" x-transition class="fixed top-4 right-4 z-50 w-full max-w-sm rounded-xl border px-4 py-3 shadow-lg" :class="toast.variant === 'success' ? 'border-emerald-200 bg-emerald-50/90 text-emerald-800' : 'border-rose-200 bg-rose-50/90 text-rose-700'" role="status" aria-live="polite">
+          <div class="flex items-start gap-3">
+            <span class="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full" :class="toast.variant === 'success' ? 'bg-emerald-600 text-white' : 'bg-rose-600 text-white'">
+              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><template x-if="toast.variant === 'success'"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></template><template x-if="toast.variant !== 'success'"><path d="M15 9 9 15m0-6 6 6" stroke-linecap="round" stroke-linejoin="round" /></template></svg>
+            </span>
+            <div>
+              <p class="text-sm font-semibold" x-text="toast.message"></p>
+              <p class="text-xs text-slate-500" x-text="toast.detail"></p>
+            </div>
+            <button type="button" class="ml-auto text-xs font-medium text-slate-500 hover:text-slate-700" @click="toast.visible = false">Dismiss</button>
+          </div>
+        </div>
+
+        <div x-cloak x-show="modalOpen" class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6" role="dialog" aria-modal="true">
+          <div class="absolute inset-0 bg-slate-900/40" @click="closeModal()"></div>
+          <div class="relative w-full max-w-xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl" x-trap.noscroll="modalOpen" x-transition>
+            <header class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-xs uppercase tracking-widest text-slate-400" x-text="isEditing ? 'Update student' : 'Create student'"></p>
+                <h2 class="text-2xl font-semibold text-slate-900" x-text="isEditing ? 'Edit student' : 'Add new student'"></h2>
+              </div>
+              <button type="button" class="rounded-lg border border-transparent p-2 text-slate-400 hover:text-slate-600" @click="closeModal()" aria-label="Close dialog">
+                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 9l6 6m0-6-6 6" stroke-linecap="round" /></svg>
+              </button>
+            </header>
+            <form class="mt-6 space-y-4" @submit.prevent="saveStudent()">
+              <div>
+                <label for="student-id" class="text-sm font-medium text-slate-700">Student ID</label>
+                <input id="student-id" type="text" x-model="form._id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors._id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. S-1101" required />
+                <p class="mt-1 text-xs text-slate-500">Use the institutional identifier students receive upon enrollment.</p>
+                <p x-show="errors._id" x-text="errors._id" class="mt-1 text-xs font-medium text-rose-600"></p>
+              </div>
+              <div>
+                <label for="student-name" class="text-sm font-medium text-slate-700">Full name</label>
+                <input id="student-name" type="text" x-model="form.full_name" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.full_name ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. Jordan Rivers" required />
+                <p class="mt-1 text-xs text-slate-500">Legal display name used on transcripts.</p>
+                <p x-show="errors.full_name" x-text="errors.full_name" class="mt-1 text-xs font-medium text-rose-600"></p>
+              </div>
+              <div>
+                <label for="student-email" class="text-sm font-medium text-slate-700">Email address</label>
+                <input id="student-email" type="email" x-model="form.email" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.email ? 'border-rose-300' : 'border-slate-200'" placeholder="name@example.edu" required />
+                <p class="mt-1 text-xs text-slate-500">Institution-issued email only.</p>
+                <p x-show="errors.email" x-text="errors.email" class="mt-1 text-xs font-medium text-rose-600"></p>
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label for="student-major" class="text-sm font-medium text-slate-700">Major department</label>
+                  <select id="student-major" x-model="form.major_dept_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.major_dept_id ? 'border-rose-300' : 'border-slate-200'" required>
+                    <option value="" disabled>Select department</option>
+                    <template x-for="dept in departments" :key="dept.id">
+                      <option :value="dept.id" x-text="`${dept.name} (${dept.id})`"></option>
+                    </template>
+                  </select>
+                  <p class="mt-1 text-xs text-slate-500">Students may have multiple majors; select the primary.</p>
+                  <p x-show="errors.major_dept_id" x-text="errors.major_dept_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+                </div>
+                <div>
+                  <label for="student-year" class="text-sm font-medium text-slate-700">Grad year</label>
+                  <select id="student-year" x-model="form.year" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.year ? 'border-rose-300' : 'border-slate-200'" required>
+                    <option value="" disabled>Select year</option>
+                    <template x-for="year in yearOptions" :key="year">
+                      <option x-text="year"></option>
+                    </template>
+                  </select>
+                  <p class="mt-1 text-xs text-slate-500">Graduation year projected by the registrar.</p>
+                  <p x-show="errors.year" x-text="errors.year" class="mt-1 text-xs font-medium text-rose-600"></p>
+                </div>
+              </div>
+              <div>
+                <label for="student-pronouns" class="text-sm font-medium text-slate-700">Pronouns <span class="text-slate-400">(optional)</span></label>
+                <input id="student-pronouns" type="text" x-model="form.pronouns" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. she/her" />
+                <p class="mt-1 text-xs text-slate-500">Shared with advisors and faculty rosters.</p>
+              </div>
+              <div class="flex items-center justify-end gap-3 pt-4">
+                <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300" @click="closeModal()">Cancel</button>
+                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                  Save student
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const studentSeed = [
+      { _id: 'S-1001', full_name: 'Asha Patel', email: 'asha.patel@example.edu', major_dept_id: 'CS', year: '2025', pronouns: 'she/her' },
+      { _id: 'S-1002', full_name: 'Ethan Wright', email: 'ethan.wright@example.edu', major_dept_id: 'MATH', year: '2026', pronouns: 'he/him' },
+      { _id: 'S-1003', full_name: 'Lina Alvarez', email: 'lina.alvarez@example.edu', major_dept_id: 'BIO', year: '2025', pronouns: 'she/they' },
+      { _id: 'S-1004', full_name: 'Noah Kim', email: 'noah.kim@example.edu', major_dept_id: 'CS', year: '2027', pronouns: 'he/him' },
+      { _id: 'S-1005', full_name: 'Maya Chen', email: 'maya.chen@example.edu', major_dept_id: 'ECON', year: '2024', pronouns: 'she/her' },
+      { _id: 'S-1006', full_name: 'Gabriel Souza', email: 'gabriel.souza@example.edu', major_dept_id: 'PHYS', year: '2026', pronouns: 'he/him' },
+      { _id: 'S-1007', full_name: 'Leah Johnson', email: 'leah.johnson@example.edu', major_dept_id: 'CS', year: '2025', pronouns: 'she/her' },
+      { _id: 'S-1008', full_name: 'Omar Ali', email: 'omar.ali@example.edu', major_dept_id: 'ECON', year: '2027', pronouns: 'he/him' }
+    ];
+
+    const departmentOptions = [
+      { id: 'CS', name: 'Computer Science' },
+      { id: 'MATH', name: 'Mathematics' },
+      { id: 'BIO', name: 'Biology' },
+      { id: 'PHYS', name: 'Physics' },
+      { id: 'ECON', name: 'Economics' },
+      { id: 'BUS', name: 'Business Administration' }
+    ];
+
+    const years = ['2024', '2025', '2026', '2027', '2028'];
+
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('studentsPage', () => ({
+        search: '',
+        loading: true,
+        students: [],
+        modalOpen: false,
+        isEditing: false,
+        form: { _id: '', full_name: '', email: '', major_dept_id: '', year: '', pronouns: '' },
+        errors: {},
+        toast: { visible: false, message: '', detail: '', variant: 'success' },
+        departments: departmentOptions,
+        yearOptions: years,
+        get departmentMap() {
+          return this.departments.reduce((acc, dept) => ({ ...acc, [dept.id]: dept.name }), {});
+        },
+        get filteredStudents() {
+          if (!this.search.trim()) return this.students;
+          const term = this.search.toLowerCase();
+          return this.students.filter((student) => {
+            return [student._id, student.full_name, student.email, this.departmentMap[student.major_dept_id]].some((value) =>
+              (value || '').toLowerCase().includes(term)
+            );
+          });
+        },
+        get classYears() {
+          return new Set(this.students.map((student) => student.year)).size;
+        },
+        init() {
+          setTimeout(() => {
+            this.students = studentSeed.map((student) => ({ ...student }));
+            this.loading = false;
+          }, 500);
+        },
+        openCreate() {
+          this.isEditing = false;
+          this.form = { _id: '', full_name: '', email: '', major_dept_id: '', year: '', pronouns: '' };
+          this.errors = {};
+          this.modalOpen = true;
+        },
+        openEdit(student) {
+          this.isEditing = true;
+          this.form = { ...student };
+          this.errors = {};
+          this.modalOpen = true;
+        },
+        closeModal() {
+          this.modalOpen = false;
+        },
+        validate() {
+          const nextErrors = {};
+          if (!this.form._id.trim()) nextErrors._id = 'Student ID is required.';
+          if (!this.form.full_name.trim()) nextErrors.full_name = 'Full name is required.';
+          if (!this.form.email.trim()) {
+            nextErrors.email = 'Email is required.';
+          } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.form.email)) {
+            nextErrors.email = 'Enter a valid email address.';
+          }
+          if (!this.form.major_dept_id) nextErrors.major_dept_id = 'Select a primary department.';
+          if (!this.form.year) nextErrors.year = 'Choose an expected graduation year.';
+          this.errors = nextErrors;
+          return Object.keys(nextErrors).length === 0;
+        },
+        saveStudent() {
+          if (!this.validate()) {
+            this.showToast('Please fix the highlighted fields.', 'error', 'Missing required information');
+            return;
+          }
+          if (this.isEditing) {
+            const index = this.students.findIndex((student) => student._id === this.form._id);
+            if (index !== -1) {
+              this.students.splice(index, 1, { ...this.form });
+              this.showToast('Student updated successfully.', 'success', 'Changes are saved locally.');
+            }
+          } else {
+            if (this.students.some((student) => student._id === this.form._id)) {
+              this.errors._id = 'A student with this ID already exists.';
+              this.showToast('Duplicate student ID.', 'error', 'Use a unique identifier.');
+              return;
+            }
+            this.students = [...this.students, { ...this.form }];
+            this.showToast('Student added to roster.', 'success', 'Remember to sync with the SIS.');
+          }
+          this.closeModal();
+        },
+        deleteStudent(id) {
+          if (!window.confirm('Remove this student from the roster?')) {
+            return;
+          }
+          this.students = this.students.filter((student) => student._id !== id);
+          this.showToast('Student removed.', 'success', 'The change is reflected instantly.');
+        },
+        showToast(message, variant = 'success', detail = '') {
+          this.toast = { visible: true, message, variant, detail };
+          setTimeout(() => {
+            this.toast.visible = false;
+          }, 3200);
+        }
+      }));
+    });
+  </script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,41 @@
+/* Custom utilities complementing Tailwind */
+[x-cloak] { display: none !important; }
+
+html { color-scheme: light; }
+
+::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.7);
+  border-radius: 9999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(100, 116, 139, 0.85);
+}
+
+.table-sticky-header thead th {
+  position: sticky;
+  top: 0;
+  background-color: rgb(248 250 252 / 0.95);
+  backdrop-filter: blur(4px);
+}
+
+.shadow-smooth {
+  box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.25);
+}
+
+.skeleton-line {
+  background: linear-gradient(90deg, rgba(226,232,240,0.6) 25%, rgba(241,245,249,0.9) 50%, rgba(226,232,240,0.6) 75%);
+  background-size: 400% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}


### PR DESCRIPTION
## Summary
- replace the dashboard with a responsive Tailwind layout featuring KPI cards, charts, and navigation
- build dedicated Students, Courses, Sections, and Enrollments pages with Alpine-driven filtering and mock CRUD interactions
- add shared styling utilities, placeholder logo, and README run/seed instructions

## Testing
- python -c "from backend.app import app; app.run(host='0.0.0.0', port=5000, debug=True)" (manual)


------
https://chatgpt.com/codex/tasks/task_e_68d7650367908333b8217eecb78aa6a7