### PR TITLE
feat: wire catalog CRUD and dashboard stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Modernized administrative dashboard powered by Flask (backend) and a static Tail
    ```bash
    python backend/app.py
    ```
-6. Visit [http://localhost:5000](http://localhost:5000) to explore the dashboard and Students page backed by live data.
+6. Visit [http://localhost:5000](http://localhost:5000) to explore the dashboard, Students page, and new catalog/enrollment tools backed by live data.
 
 > **Note:** Keep `backend/.env` out of version control. The repository `.gitignore` already excludes it.
 
@@ -37,17 +37,75 @@ Modernized administrative dashboard powered by Flask (backend) and a static Tail
 
 All endpoints return JSON. Errors follow the shape `{ "error": "message", "details": { ... } }`.
 
-| Method | Endpoint                  | Description                                      |
-| ------ | ------------------------- | ------------------------------------------------ |
-| GET    | `/api/health`             | Health probe for monitoring.                     |
-| GET    | `/api/students`           | List students. Supports `q`, `major`, `limit`.   |
-| POST   | `/api/students`           | Create a student (ID, name, email, major, year). |
-| PUT    | `/api/students/<id>`      | Update a student's attributes.                   |
-| DELETE | `/api/students/<id>`      | Remove a student record.                         |
+| Method | Endpoint                     | Description                                                         |
+| ------ | ---------------------------- | ------------------------------------------------------------------- |
+| GET    | `/api/health`                | Health probe for monitoring.                                        |
+| GET    | `/api/students`              | List students. Supports `q`, `major`, `limit`.                      |
+| POST   | `/api/students`              | Create a student (ID, name, email, major, year).                    |
+| PUT    | `/api/students/<id>`         | Update a student's attributes.                                      |
+| DELETE | `/api/students/<id>`         | Remove a student record.                                            |
+| GET    | `/api/courses`               | List courses with optional `q`, `dept`, and `limit` filters.        |
+| POST   | `/api/courses`               | Create a course (ID, title, dept, credits).                         |
+| PUT    | `/api/courses/<id>`          | Update course metadata.                                             |
+| DELETE | `/api/courses/<id>`          | Remove a course (response includes number of remaining sections).   |
+| GET    | `/api/sections`              | List class sections. Filters: `course_id`, `semester`, `instructor`. |
+| POST   | `/api/sections`              | Create a class section tied to an existing course.                  |
+| PUT    | `/api/sections/<id>`         | Update section schedule, instructor, or capacity.                   |
+| DELETE | `/api/sections/<id>`         | Remove a section (response includes impacted enrollments).          |
+| GET    | `/api/enrollments`           | List enrollments. Filters: `student_id`, `section_id`, `semester`.  |
+| POST   | `/api/enrollments`           | Create an enrollment; validates student & section existence.        |
+| PUT    | `/api/enrollments/<id>`      | Update enrollment grades/section; recalculates the letter grade.    |
+| DELETE | `/api/enrollments/<id>`      | Remove an enrollment record.                                        |
+| GET    | `/api/stats`                 | Aggregated dashboard metrics and chart data.                        |
 
 Emails are enforced unique at the database level; duplicate submissions return HTTP `409`.
 
-Optional attributes include `pronouns` and `phone`. Graduation years are stored as integers.
+Optional student attributes include `pronouns` and `phone`. Graduation years are stored as integers.
+
+Courses accept optional `description` text and prerequisite IDs. Sections require an existing course and capture capacity, room, and meeting pattern. Enrollments validate both the student and section foreign keys; if midterm/final/bonus scores are provided the API computes a letter grade automatically.
+
+### Sample cURL
+
+```bash
+# Create a course
+curl -X POST http://localhost:5000/api/courses \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "_id": "CS350",
+    "title": "Operating Systems",
+    "dept_id": "CS",
+    "credits": 4,
+    "description": "Processes, concurrency, and resource management"
+  }'
+
+# Create a section for that course
+curl -X POST http://localhost:5000/api/sections \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "_id": "SEC-CS350-2025B-01",
+    "course_id": "CS350",
+    "semester": "2025B",
+    "section_no": "01",
+    "instructor_id": "I-4001",
+    "capacity": 30,
+    "room": "ENG-410"
+  }'
+
+# Enroll an existing student and include scores
+curl -X POST http://localhost:5000/api/enrollments \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "student_id": "S-1001",
+    "section_id": "SEC-CS350-2025B-01",
+    "semester": "2025B",
+    "midterm": 90,
+    "final": 94,
+    "bonus": 1
+  }'
+
+# Dashboard stats
+curl http://localhost:5000/api/stats
+```
 
 ## Seeding scripts
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,13 +2,23 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 from flask import Flask, jsonify, request, send_from_directory
 from pymongo.errors import DuplicateKeyError, PyMongoError
 
 from src.config import ConfigError
-from src.db import get_students_collection, serialize_student
+from src.db import (
+    get_courses_collection,
+    get_enrollments_collection,
+    get_sections_collection,
+    get_students_collection,
+    serialize_course,
+    serialize_enrollment,
+    serialize_section,
+    serialize_student,
+    get_db,
+)
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_FOLDER = BASE_DIR.parent / "frontend"
@@ -27,6 +37,67 @@ def _json_error(message: str, status: int, details: Dict[str, str] | None = None
 
 def _clean_string(value: Any) -> str:
     return str(value).strip() if value is not None else ""
+
+
+def _clean_string_or_none(value: Any) -> str | None:
+    cleaned = _clean_string(value)
+    return cleaned if cleaned else None
+
+
+def _parse_limit_arg(limit_arg: str | None) -> int | None:
+    if not limit_arg:
+        return None
+    try:
+        value = int(limit_arg)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be a positive integer.")
+    if value <= 0:
+        raise ValueError("limit must be a positive integer.")
+    return value
+
+
+def _calculate_letter_grade(
+    midterm: float | None, final: float | None, bonus: float | None
+) -> str | None:
+    scores: List[Tuple[float, float]] = []
+    if midterm is not None:
+        scores.append((midterm, 0.4))
+    if final is not None:
+        scores.append((final, 0.6))
+
+    if not scores:
+        return None
+
+    total_weight = sum(weight for _, weight in scores)
+    if total_weight == 0:
+        return None
+
+    weighted_score = sum(score * weight for score, weight in scores) / total_weight
+    if bonus is not None:
+        weighted_score += bonus
+
+    weighted_score = max(0.0, min(100.0, weighted_score))
+
+    grade_scale = [
+        (97, "A+"),
+        (93, "A"),
+        (90, "A-"),
+        (87, "B+"),
+        (83, "B"),
+        (80, "B-"),
+        (77, "C+"),
+        (73, "C"),
+        (70, "C-"),
+        (67, "D+"),
+        (63, "D"),
+        (60, "D-"),
+        (0, "F"),
+    ]
+
+    for threshold, letter in grade_scale:
+        if weighted_score >= threshold:
+            return letter
+    return None
 
 
 def _validate_student_payload(
@@ -80,6 +151,179 @@ def _validate_student_payload(
     # Remove keys with None values so we don't overwrite with null unless explicit
     cleaned = {k: v for k, v in cleaned.items() if v is not None}
 
+    return cleaned, errors
+
+
+def _validate_course_payload(
+    payload: Dict[str, Any] | None, *, require_all: bool
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    if payload is None:
+        return {}, {"_global": "Request body must be JSON."}
+
+    errors: Dict[str, str] = {}
+    cleaned: Dict[str, Any] = {}
+
+    def require_field(field: str, message: str) -> bool:
+        if field not in payload or _clean_string(payload.get(field)) == "":
+            errors[field] = message
+            return False
+        return True
+
+    if require_all or "_id" in payload:
+        if require_field("_id", "Course ID is required."):
+            cleaned["_id"] = _clean_string(payload.get("_id"))
+
+    if require_all or "title" in payload:
+        if require_field("title", "Course title is required."):
+            cleaned["title"] = _clean_string(payload.get("title"))
+
+    if require_all or "dept_id" in payload:
+        if require_field("dept_id", "Department code is required."):
+            cleaned["dept_id"] = _clean_string(payload.get("dept_id"))
+
+    if require_all or "credits" in payload:
+        if "credits" not in payload or payload.get("credits") in (None, ""):
+            if require_all:
+                errors["credits"] = "Credits are required."
+        else:
+            try:
+                credits_value = int(float(payload.get("credits")))
+                if credits_value <= 0:
+                    raise ValueError
+                cleaned["credits"] = credits_value
+            except (TypeError, ValueError):
+                errors["credits"] = "Credits must be a positive number."
+
+    if "description" in payload:
+        cleaned["description"] = _clean_string(payload.get("description"))
+
+    if "prereq_ids" in payload:
+        prereqs = payload.get("prereq_ids")
+        if prereqs in (None, ""):
+            cleaned["prereq_ids"] = []
+        elif isinstance(prereqs, list):
+            cleaned["prereq_ids"] = [
+                _clean_string(value) for value in prereqs if _clean_string(value)
+            ]
+        else:
+            errors["prereq_ids"] = "Prerequisites must be an array of course IDs."
+
+    keep_none_fields = {"midterm", "final", "bonus"}
+    cleaned = {
+        k: v for k, v in cleaned.items() if v is not None or k in keep_none_fields
+    }
+    return cleaned, errors
+
+
+def _validate_section_payload(
+    payload: Dict[str, Any] | None, *, require_all: bool
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    if payload is None:
+        return {}, {"_global": "Request body must be JSON."}
+
+    errors: Dict[str, str] = {}
+    cleaned: Dict[str, Any] = {}
+
+    def require_field(field: str, message: str) -> bool:
+        if field not in payload or _clean_string(payload.get(field)) == "":
+            errors[field] = message
+            return False
+        return True
+
+    if require_all or "_id" in payload:
+        if require_field("_id", "Section ID is required."):
+            cleaned["_id"] = _clean_string(payload.get("_id"))
+
+    if require_all or "course_id" in payload:
+        if require_field("course_id", "Course ID is required."):
+            cleaned["course_id"] = _clean_string(payload.get("course_id"))
+
+    if require_all or "semester" in payload:
+        if require_field("semester", "Semester is required."):
+            cleaned["semester"] = _clean_string(payload.get("semester")).upper()
+
+    if require_all or "section_no" in payload:
+        if require_field("section_no", "Section number is required."):
+            cleaned["section_no"] = _clean_string(payload.get("section_no"))
+
+    if require_all or "instructor_id" in payload:
+        if require_field("instructor_id", "Instructor ID is required."):
+            cleaned["instructor_id"] = _clean_string(payload.get("instructor_id"))
+
+    if require_all or "capacity" in payload:
+        if payload.get("capacity") in (None, ""):
+            if require_all:
+                errors["capacity"] = "Capacity is required."
+        else:
+            try:
+                capacity_value = int(float(payload.get("capacity")))
+                if capacity_value < 0:
+                    raise ValueError
+                cleaned["capacity"] = capacity_value
+            except (TypeError, ValueError):
+                errors["capacity"] = "Capacity must be a non-negative number."
+
+    if "room" in payload:
+        cleaned["room"] = _clean_string(payload.get("room"))
+
+    if "schedule" in payload:
+        schedule = payload.get("schedule")
+        if schedule in (None, ""):
+            cleaned["schedule"] = []
+        elif isinstance(schedule, list):
+            cleaned["schedule"] = [
+                _clean_string(entry) for entry in schedule if _clean_string(entry)
+            ]
+        else:
+            errors["schedule"] = "Schedule must be an array of strings."
+
+    cleaned = {k: v for k, v in cleaned.items() if v is not None}
+    return cleaned, errors
+
+
+def _validate_enrollment_payload(
+    payload: Dict[str, Any] | None, *, require_all: bool
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    if payload is None:
+        return {}, {"_global": "Request body must be JSON."}
+
+    errors: Dict[str, str] = {}
+    cleaned: Dict[str, Any] = {}
+
+    def require_field(field: str, message: str) -> bool:
+        if field not in payload or _clean_string(payload.get(field)) == "":
+            errors[field] = message
+            return False
+        return True
+
+    if require_all or "_id" in payload:
+        if "_id" in payload and payload.get("_id") not in (None, ""):
+            cleaned["_id"] = _clean_string(payload.get("_id"))
+        elif require_all:
+            errors["_id"] = "Enrollment ID is required."
+
+    if require_all or "student_id" in payload:
+        if require_field("student_id", "Student ID is required."):
+            cleaned["student_id"] = _clean_string(payload.get("student_id"))
+
+    if require_all or "section_id" in payload:
+        if require_field("section_id", "Section ID is required."):
+            cleaned["section_id"] = _clean_string(payload.get("section_id"))
+
+    if require_all or "semester" in payload:
+        if require_field("semester", "Semester is required."):
+            cleaned["semester"] = _clean_string(payload.get("semester")).upper()
+
+    for field in ("midterm", "final", "bonus"):
+        if field in payload and payload.get(field) not in (None, ""):
+            try:
+                cleaned[field] = float(payload.get(field))
+            except (TypeError, ValueError):
+                errors[field] = "Scores must be numeric."
+        elif field in payload:
+            cleaned[field] = None
+
+    cleaned = {k: v for k, v in cleaned.items() if v is not None}
     return cleaned, errors
 
 
@@ -220,6 +464,635 @@ def delete_student(student_id: str):
         return _handle_config_error(exc)
     except PyMongoError as exc:
         return _handle_db_error("Failed to delete student", exc)
+
+
+@app.get("/api/courses")
+def list_courses():
+    try:
+        collection = get_courses_collection()
+        filters: Dict[str, Any] = {}
+
+        query = _clean_string(request.args.get("q"))
+        dept = _clean_string(request.args.get("dept"))
+        limit_arg = request.args.get("limit")
+
+        if query:
+            filters["$or"] = [
+                {"title": {"$regex": query, "$options": "i"}},
+                {"_id": {"$regex": query, "$options": "i"}},
+            ]
+        if dept:
+            filters["dept_id"] = dept
+
+        projection = {
+            "_id": 1,
+            "title": 1,
+            "dept_id": 1,
+            "credits": 1,
+            "description": 1,
+            "prereq_ids": 1,
+        }
+
+        cursor = collection.find(filters, projection=projection, sort=[("title", 1)])
+        try:
+            limit_value = _parse_limit_arg(limit_arg)
+        except ValueError as exc:
+            return _json_error(str(exc), 400)
+        if limit_value:
+            cursor = cursor.limit(limit_value)
+
+        courses = []
+        for doc in cursor:
+            serialized = serialize_course(doc)
+            if serialized.get("description") is None:
+                serialized["description"] = ""
+            courses.append(serialized)
+        return jsonify(courses)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to list courses", exc)
+
+
+@app.post("/api/courses")
+def create_course():
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_course_payload(data, require_all=True)
+    if errors:
+        details = {k: v for k, v in errors.items() if k != "_global"}
+        message = errors.get("_global", "Validation failed.")
+        return _json_error(message, 400, details if details else None)
+
+    try:
+        collection = get_courses_collection()
+        collection.insert_one(cleaned)
+        created = collection.find_one({"_id": cleaned["_id"]})
+        return jsonify(serialize_course(created or cleaned)), 201
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Course with this ID already exists.", 409, {"_id": "Choose a different course ID."})
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to create course", exc)
+
+
+@app.put("/api/courses/<course_id>")
+def update_course(course_id: str):
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_course_payload(data, require_all=False)
+
+    if "_id" in cleaned and cleaned["_id"] != course_id:
+        errors["_id"] = "Course ID cannot be changed."
+
+    if errors:
+        return _json_error("Validation failed.", 400, errors)
+
+    if not cleaned:
+        return _json_error("No changes supplied.", 400)
+
+    try:
+        collection = get_courses_collection()
+        result = collection.update_one({"_id": course_id}, {"$set": cleaned})
+        if result.matched_count == 0:
+            return _json_error("Course not found.", 404)
+        updated = collection.find_one({"_id": course_id})
+        return jsonify(serialize_course(updated or cleaned))
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Course with this ID already exists.", 409, {"_id": "Choose a different course ID."})
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to update course", exc)
+
+
+@app.delete("/api/courses/<course_id>")
+def delete_course(course_id: str):
+    try:
+        collection = get_courses_collection()
+        result = collection.delete_one({"_id": course_id})
+        if result.deleted_count == 0:
+            return _json_error("Course not found.", 404)
+        sections_collection = get_sections_collection()
+        active_sections = sections_collection.count_documents({"course_id": course_id})
+        return jsonify({"deleted": True, "active_sections": active_sections})
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to delete course", exc)
+
+
+@app.get("/api/sections")
+def list_sections():
+    try:
+        collection = get_sections_collection()
+        filters: Dict[str, Any] = {}
+
+        course_id = _clean_string(request.args.get("course_id"))
+        semester = _clean_string(request.args.get("semester"))
+        instructor_id = _clean_string(request.args.get("instructor_id"))
+        limit_arg = request.args.get("limit")
+
+        if course_id:
+            filters["course_id"] = course_id
+        if semester:
+            filters["semester"] = semester.upper()
+        if instructor_id:
+            filters["instructor_id"] = instructor_id
+
+        projection = {
+            "_id": 1,
+            "course_id": 1,
+            "semester": 1,
+            "section_no": 1,
+            "instructor_id": 1,
+            "capacity": 1,
+            "room": 1,
+            "schedule": 1,
+        }
+
+        cursor = collection.find(filters, projection=projection, sort=[("semester", -1), ("section_no", 1)])
+        try:
+            limit_value = _parse_limit_arg(limit_arg)
+        except ValueError as exc:
+            return _json_error(str(exc), 400)
+        if limit_value:
+            cursor = cursor.limit(limit_value)
+
+        sections = list(cursor)
+        course_ids = {doc.get("course_id") for doc in sections if doc.get("course_id")}
+        courses_map: Dict[str, Dict[str, Any]] = {}
+        if course_ids:
+            courses_cursor = get_courses_collection().find(
+                {"_id": {"$in": list(course_ids)}},
+                projection={"_id": 1, "title": 1, "dept_id": 1, "credits": 1},
+            )
+            courses_map = {doc["_id"]: doc for doc in courses_cursor}
+
+        payload: List[Dict[str, Any]] = []
+        for doc in sections:
+            serialized = serialize_section(doc)
+            course = courses_map.get(serialized["course_id"])
+            serialized["course_title"] = course.get("title") if course else None
+            serialized["course_dept_id"] = course.get("dept_id") if course else None
+            serialized["course_credits"] = course.get("credits") if course else None
+            payload.append(serialized)
+
+        return jsonify(payload)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to list sections", exc)
+
+
+def _ensure_course_exists(course_id: str) -> bool:
+    courses_collection = get_courses_collection()
+    return bool(courses_collection.find_one({"_id": course_id}, projection={"_id": 1}))
+
+
+@app.post("/api/sections")
+def create_section():
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_section_payload(data, require_all=True)
+    if errors:
+        details = {k: v for k, v in errors.items() if k != "_global"}
+        message = errors.get("_global", "Validation failed.")
+        return _json_error(message, 400, details if details else None)
+
+    try:
+        if not _ensure_course_exists(cleaned["course_id"]):
+            return _json_error("Course not found for section.", 400, {"course_id": "Select an existing course."})
+
+        collection = get_sections_collection()
+        collection.insert_one(cleaned)
+        created = collection.find_one({"_id": cleaned["_id"]})
+        response = serialize_section(created or cleaned)
+        course_doc = get_courses_collection().find_one(
+            {"_id": response["course_id"]}, projection={"title": 1, "dept_id": 1, "credits": 1}
+        )
+        if course_doc:
+            response["course_title"] = course_doc.get("title")
+            response["course_dept_id"] = course_doc.get("dept_id")
+            response["course_credits"] = course_doc.get("credits")
+        return jsonify(response), 201
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Section with this ID already exists.", 409, {"_id": "Choose a different section ID."})
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to create section", exc)
+
+
+@app.put("/api/sections/<section_id>")
+def update_section(section_id: str):
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_section_payload(data, require_all=False)
+
+    if "_id" in cleaned and cleaned["_id"] != section_id:
+        errors["_id"] = "Section ID cannot be changed."
+
+    if errors:
+        return _json_error("Validation failed.", 400, errors)
+
+    if not cleaned:
+        return _json_error("No changes supplied.", 400)
+
+    try:
+        if "course_id" in cleaned and not _ensure_course_exists(cleaned["course_id"]):
+            return _json_error("Course not found for section.", 400, {"course_id": "Select an existing course."})
+
+        collection = get_sections_collection()
+        result = collection.update_one({"_id": section_id}, {"$set": cleaned})
+        if result.matched_count == 0:
+            return _json_error("Section not found.", 404)
+
+        updated = collection.find_one({"_id": section_id})
+        response = serialize_section(updated or cleaned)
+        course_doc = None
+        if response.get("course_id"):
+            course_doc = get_courses_collection().find_one(
+                {"_id": response["course_id"]}, projection={"title": 1, "dept_id": 1, "credits": 1}
+            )
+        if course_doc:
+            response["course_title"] = course_doc.get("title")
+            response["course_dept_id"] = course_doc.get("dept_id")
+            response["course_credits"] = course_doc.get("credits")
+        return jsonify(response)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Section with this ID already exists.", 409, {"_id": "Choose a different section ID."})
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to update section", exc)
+
+
+@app.delete("/api/sections/<section_id>")
+def delete_section(section_id: str):
+    try:
+        collection = get_sections_collection()
+        result = collection.delete_one({"_id": section_id})
+        if result.deleted_count == 0:
+            return _json_error("Section not found.", 404)
+        enrollments_collection = get_enrollments_collection()
+        affected = enrollments_collection.count_documents({"section_id": section_id})
+        return jsonify({"deleted": True, "enrollments": affected})
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to delete section", exc)
+
+
+def _ensure_student_exists(student_id: str) -> bool:
+    collection = get_students_collection()
+    return bool(collection.find_one({"_id": student_id}, projection={"_id": 1}))
+
+
+def _ensure_section_exists(section_id: str) -> bool:
+    collection = get_sections_collection()
+    return bool(collection.find_one({"_id": section_id}, projection={"_id": 1, "semester": 1}))
+
+
+@app.get("/api/enrollments")
+def list_enrollments():
+    try:
+        collection = get_enrollments_collection()
+        filters: Dict[str, Any] = {}
+
+        student_id = _clean_string(request.args.get("student_id"))
+        section_id = _clean_string(request.args.get("section_id"))
+        semester = _clean_string(request.args.get("semester"))
+
+        if student_id:
+            filters["student_id"] = student_id
+        if section_id:
+            filters["section_id"] = section_id
+        if semester:
+            filters["semester"] = semester.upper()
+
+        documents = list(
+            collection.find(
+                filters,
+                sort=[("semester", -1), ("student_id", 1)],
+            )
+        )
+
+        student_ids = {doc.get("student_id") for doc in documents if doc.get("student_id")}
+        section_ids = {doc.get("section_id") for doc in documents if doc.get("section_id")}
+
+        students_map: Dict[str, Dict[str, Any]] = {}
+        sections_map: Dict[str, Dict[str, Any]] = {}
+        courses_map: Dict[str, Dict[str, Any]] = {}
+
+        if student_ids:
+            students_cursor = get_students_collection().find(
+                {"_id": {"$in": list(student_ids)}},
+                projection={"_id": 1, "full_name": 1},
+            )
+            students_map = {doc["_id"]: doc for doc in students_cursor}
+
+        if section_ids:
+            sections_cursor = get_sections_collection().find(
+                {"_id": {"$in": list(section_ids)}},
+                projection={
+                    "_id": 1,
+                    "course_id": 1,
+                    "semester": 1,
+                    "section_no": 1,
+                    "instructor_id": 1,
+                },
+            )
+            sections_map = {doc["_id"]: doc for doc in sections_cursor}
+
+        course_ids = {
+            section.get("course_id")
+            for section in sections_map.values()
+            if section.get("course_id")
+        }
+        if course_ids:
+            courses_cursor = get_courses_collection().find(
+                {"_id": {"$in": list(course_ids)}},
+                projection={"_id": 1, "title": 1, "dept_id": 1},
+            )
+            courses_map = {doc["_id"]: doc for doc in courses_cursor}
+
+        payload: List[Dict[str, Any]] = []
+        for doc in documents:
+            serialized = serialize_enrollment(doc)
+            student = students_map.get(serialized["student_id"])
+            section = sections_map.get(serialized["section_id"])
+            course = courses_map.get(section.get("course_id")) if section else None
+
+            serialized["student_name"] = student.get("full_name") if student else None
+            if section:
+                serialized["course_id"] = section.get("course_id")
+                serialized["section_no"] = section.get("section_no")
+                serialized["instructor_id"] = section.get("instructor_id")
+                serialized.setdefault("semester", section.get("semester"))
+            if course:
+                serialized["course_title"] = course.get("title")
+                serialized["course_dept_id"] = course.get("dept_id")
+
+            payload.append(serialized)
+
+        return jsonify(payload)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to list enrollments", exc)
+
+
+@app.post("/api/enrollments")
+def create_enrollment():
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_enrollment_payload(data, require_all=True)
+    if errors:
+        details = {k: v for k, v in errors.items() if k != "_global"}
+        message = errors.get("_global", "Validation failed.")
+        return _json_error(message, 400, details if details else None)
+
+    try:
+        if not _ensure_student_exists(cleaned["student_id"]):
+            return _json_error("Student not found for enrollment.", 400, {"student_id": "Select an existing student."})
+        if not _ensure_section_exists(cleaned["section_id"]):
+            return _json_error("Section not found for enrollment.", 400, {"section_id": "Select an existing section."})
+
+        if "_id" not in cleaned or not cleaned["_id"]:
+            cleaned["_id"] = f"{cleaned['student_id']}:{cleaned['section_id']}"
+
+        letter = _calculate_letter_grade(
+            cleaned.get("midterm"), cleaned.get("final"), cleaned.get("bonus")
+        )
+        if letter:
+            cleaned["letter"] = letter
+
+        collection = get_enrollments_collection()
+        collection.insert_one(cleaned)
+        created = collection.find_one({"_id": cleaned["_id"]})
+        serialized = serialize_enrollment(created or cleaned)
+        section = get_sections_collection().find_one(
+            {"_id": serialized["section_id"]},
+            projection={"course_id": 1, "section_no": 1, "instructor_id": 1, "semester": 1},
+        )
+        student = get_students_collection().find_one(
+            {"_id": serialized["student_id"]}, projection={"full_name": 1}
+        )
+        course_doc = None
+        if section and section.get("course_id"):
+            course_doc = get_courses_collection().find_one(
+                {"_id": section["course_id"]}, projection={"title": 1, "dept_id": 1}
+            )
+
+        serialized["student_name"] = student.get("full_name") if student else None
+        if section:
+            serialized["course_id"] = section.get("course_id")
+            serialized["section_no"] = section.get("section_no")
+            serialized["instructor_id"] = section.get("instructor_id")
+            serialized.setdefault("semester", section.get("semester"))
+        if course_doc:
+            serialized["course_title"] = course_doc.get("title")
+            serialized["course_dept_id"] = course_doc.get("dept_id")
+
+        return jsonify(serialized), 201
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Enrollment already exists for this student and section.", 409)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to create enrollment", exc)
+
+
+@app.put("/api/enrollments/<enrollment_id>")
+def update_enrollment(enrollment_id: str):
+    data = request.get_json(silent=True)
+    cleaned, errors = _validate_enrollment_payload(data, require_all=False)
+
+    if "_id" in cleaned and cleaned["_id"] != enrollment_id:
+        errors["_id"] = "Enrollment ID cannot be changed."
+
+    if errors:
+        return _json_error("Validation failed.", 400, errors)
+
+    if not cleaned:
+        return _json_error("No changes supplied.", 400)
+
+    try:
+        collection = get_enrollments_collection()
+        existing = collection.find_one({"_id": enrollment_id})
+        if not existing:
+            return _json_error("Enrollment not found.", 404)
+
+        if "student_id" in cleaned and not _ensure_student_exists(cleaned["student_id"]):
+            return _json_error("Student not found for enrollment.", 400, {"student_id": "Select an existing student."})
+        if "section_id" in cleaned and not _ensure_section_exists(cleaned["section_id"]):
+            return _json_error("Section not found for enrollment.", 400, {"section_id": "Select an existing section."})
+
+        combined = existing.copy()
+        combined.update(cleaned)
+        letter = _calculate_letter_grade(
+            combined.get("midterm"), combined.get("final"), combined.get("bonus")
+        )
+
+        update_fields = cleaned.copy()
+        unset_fields: Dict[str, str] = {}
+        if letter:
+            update_fields["letter"] = letter
+        elif "letter" in combined or "letter" in existing:
+            unset_fields["letter"] = ""
+
+        update_doc: Dict[str, Any] = {}
+        if update_fields:
+            update_doc["$set"] = update_fields
+        if unset_fields:
+            update_doc["$unset"] = unset_fields
+
+        if not update_doc:
+            return _json_error("No changes supplied.", 400)
+
+        result = collection.update_one({"_id": enrollment_id}, update_doc)
+        if result.matched_count == 0:
+            return _json_error("Enrollment not found.", 404)
+
+        updated = collection.find_one({"_id": enrollment_id})
+        serialized = serialize_enrollment(updated or combined)
+
+        student = get_students_collection().find_one(
+            {"_id": serialized["student_id"]}, projection={"full_name": 1}
+        )
+        section = get_sections_collection().find_one(
+            {"_id": serialized["section_id"]},
+            projection={"course_id": 1, "section_no": 1, "instructor_id": 1, "semester": 1},
+        )
+        course_doc = None
+        if section and section.get("course_id"):
+            course_doc = get_courses_collection().find_one(
+                {"_id": section["course_id"]}, projection={"title": 1, "dept_id": 1}
+            )
+
+        serialized["student_name"] = student.get("full_name") if student else None
+        if section:
+            serialized["course_id"] = section.get("course_id")
+            serialized["section_no"] = section.get("section_no")
+            serialized["instructor_id"] = section.get("instructor_id")
+            serialized.setdefault("semester", section.get("semester"))
+        if course_doc:
+            serialized["course_title"] = course_doc.get("title")
+            serialized["course_dept_id"] = course_doc.get("dept_id")
+
+        return jsonify(serialized)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except DuplicateKeyError:
+        return _json_error("Enrollment already exists for this student and section.", 409)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to update enrollment", exc)
+
+
+@app.delete("/api/enrollments/<enrollment_id>")
+def delete_enrollment(enrollment_id: str):
+    try:
+        collection = get_enrollments_collection()
+        result = collection.delete_one({"_id": enrollment_id})
+        if result.deleted_count == 0:
+            return _json_error("Enrollment not found.", 404)
+        return jsonify({"deleted": True})
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to delete enrollment", exc)
+
+
+@app.get("/api/stats")
+def stats():
+    try:
+        get_db()  # Ensure the database connection is available
+
+        students_collection = get_students_collection()
+        enrollments_collection = get_enrollments_collection()
+
+        students_pipeline = [
+            {
+                "$group": {
+                    "_id": {"$ifNull": ["$major_dept_id", "UNDECLARED"]},
+                    "count": {"$sum": 1},
+                }
+            },
+            {"$project": {"_id": 0, "major_dept_id": "$_id", "count": 1}},
+            {"$sort": {"count": -1, "major_dept_id": 1}},
+        ]
+
+        students_by_major = list(students_collection.aggregate(students_pipeline))
+
+        enrollments_pipeline = [
+            {
+                "$group": {
+                    "_id": {"$ifNull": ["$semester", "UNKNOWN"]},
+                    "count": {"$sum": 1},
+                }
+            },
+            {"$project": {"_id": 0, "semester": "$_id", "count": 1}},
+            {"$sort": {"semester": 1}},
+        ]
+
+        enrollments_by_semester = list(
+            enrollments_collection.aggregate(enrollments_pipeline)
+        )
+
+        top_courses_pipeline = [
+            {
+                "$lookup": {
+                    "from": "class_sections",
+                    "localField": "section_id",
+                    "foreignField": "_id",
+                    "as": "section",
+                }
+            },
+            {"$unwind": "$section"},
+            {
+                "$group": {
+                    "_id": "$section.course_id",
+                    "count": {"$sum": 1},
+                }
+            },
+            {"$sort": {"count": -1}},
+            {"$limit": 5},
+            {
+                "$lookup": {
+                    "from": "courses",
+                    "localField": "_id",
+                    "foreignField": "_id",
+                    "as": "course",
+                }
+            },
+            {
+                "$unwind": {
+                    "path": "$course",
+                    "preserveNullAndEmptyArrays": True,
+                }
+            },
+            {
+                "$project": {
+                    "_id": 0,
+                    "course_id": "$_id",
+                    "count": 1,
+                    "title": {"$ifNull": ["$course.title", "$_id"]},
+                }
+            },
+        ]
+
+        top_courses_by_enrollment = list(
+            enrollments_collection.aggregate(top_courses_pipeline)
+        )
+
+        payload = {
+            "students_by_major": students_by_major,
+            "enrollments_by_semester": enrollments_by_semester,
+            "top_courses_by_enrollment": top_courses_by_enrollment,
+        }
+
+        return jsonify(payload)
+    except ConfigError as exc:
+        return _handle_config_error(exc)
+    except PyMongoError as exc:
+        return _handle_db_error("Failed to load stats", exc)
 
 
 @app.route("/")

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-from pymongo import ASCENDING, DESCENDING, MongoClient
+from pymongo import ASCENDING, DESCENDING, IndexModel, MongoClient
 from pymongo.collection import Collection
 
 from .config import get_db_name, get_mongo_uri
@@ -26,6 +26,9 @@ def get_db():
 
 
 _students_indexes_created = False
+_courses_indexes_created = False
+_sections_indexes_created = False
+_enrollments_indexes_created = False
 
 
 def _ensure_students_indexes(collection: Collection) -> None:
@@ -77,8 +80,164 @@ def serialize_student(document: Dict[str, Any]) -> Dict[str, Any]:
     return student
 
 
+def _ensure_courses_indexes(collection: Collection) -> None:
+    global _courses_indexes_created
+    if _courses_indexes_created:
+        return
+
+    collection.create_index(
+        [("dept_id", ASCENDING)],
+        name="dept_id_idx",
+        background=True,
+    )
+    _courses_indexes_created = True
+
+
+def get_courses_collection() -> Collection:
+    """Return the courses collection and ensure supporting indexes."""
+
+    collection = get_db()["courses"]
+    _ensure_courses_indexes(collection)
+    return collection
+
+
+def serialize_course(document: Dict[str, Any]) -> Dict[str, Any]:
+    """Serialize a raw Mongo course document to JSON-friendly dict."""
+
+    credits = document.get("credits")
+    try:
+        credits_value = int(credits) if credits is not None else None
+    except (TypeError, ValueError):
+        credits_value = None
+
+    prereqs = document.get("prereq_ids", [])
+    if not isinstance(prereqs, list):
+        prereqs = []
+
+    return {
+        "_id": str(document.get("_id", "")),
+        "title": document.get("title"),
+        "dept_id": document.get("dept_id"),
+        "credits": credits_value,
+        "description": document.get("description", ""),
+        "prereq_ids": prereqs,
+    }
+
+
+def _ensure_sections_indexes(collection: Collection) -> None:
+    global _sections_indexes_created
+    if _sections_indexes_created:
+        return
+
+    indexes: List[IndexModel] = [
+        IndexModel(
+            [("course_id", ASCENDING), ("semester", ASCENDING)],
+            name="course_semester",
+            background=True,
+        ),
+        IndexModel(
+            [("instructor_id", ASCENDING), ("semester", ASCENDING)],
+            name="instructor_semester",
+            background=True,
+        ),
+    ]
+    collection.create_indexes(indexes)
+    _sections_indexes_created = True
+
+
+def get_sections_collection() -> Collection:
+    """Return the class sections collection with indexes ensured."""
+
+    collection = get_db()["class_sections"]
+    _ensure_sections_indexes(collection)
+    return collection
+
+
+def serialize_section(document: Dict[str, Any]) -> Dict[str, Any]:
+    """Serialize a class section document into JSON serialisable dict."""
+
+    schedule = document.get("schedule", [])
+    if not isinstance(schedule, list):
+        schedule = []
+
+    return {
+        "_id": str(document.get("_id", "")),
+        "course_id": document.get("course_id"),
+        "semester": document.get("semester"),
+        "section_no": document.get("section_no"),
+        "instructor_id": document.get("instructor_id"),
+        "capacity": document.get("capacity"),
+        "room": document.get("room"),
+        "schedule": schedule,
+    }
+
+
+def _ensure_enrollments_indexes(collection: Collection) -> None:
+    global _enrollments_indexes_created
+    if _enrollments_indexes_created:
+        return
+
+    indexes: List[IndexModel] = [
+        IndexModel(
+            [("section_id", ASCENDING)],
+            name="section_id_idx",
+            background=True,
+        ),
+        IndexModel(
+            [("student_id", ASCENDING), ("semester", ASCENDING)],
+            name="student_semester",
+            background=True,
+        ),
+        IndexModel(
+            [("student_id", ASCENDING), ("section_id", ASCENDING)],
+            name="unique_student_section",
+            unique=True,
+            background=True,
+        ),
+    ]
+    collection.create_indexes(indexes)
+    _enrollments_indexes_created = True
+
+
+def get_enrollments_collection() -> Collection:
+    """Return the enrollments collection ensuring indexes exist."""
+
+    collection = get_db()["enrollments"]
+    _ensure_enrollments_indexes(collection)
+    return collection
+
+
+def serialize_enrollment(document: Dict[str, Any]) -> Dict[str, Any]:
+    """Serialize an enrollment document for JSON responses."""
+
+    def _score(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    return {
+        "_id": str(document.get("_id", "")),
+        "student_id": document.get("student_id"),
+        "section_id": document.get("section_id"),
+        "semester": document.get("semester"),
+        "midterm": _score(document.get("midterm")),
+        "final": _score(document.get("final")),
+        "bonus": _score(document.get("bonus")),
+        "letter": document.get("letter"),
+    }
+
+
 __all__ = [
     "get_db",
     "get_students_collection",
     "serialize_student",
+    "get_courses_collection",
+    "serialize_course",
+    "get_sections_collection",
+    "serialize_section",
+    "get_enrollments_collection",
+    "serialize_enrollment",
 ]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,21 +100,54 @@
             </div>
           </section>
 
-          <section class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-            <template x-for="card in cards" :key="card.name">
-              <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-                <div class="flex items-center justify-between">
-                  <div>
-                    <p class="text-xs uppercase tracking-wide text-slate-400" x-text="card.name"></p>
-                    <p class="mt-2 text-3xl font-semibold text-slate-900" x-text="card.value"></p>
-                  </div>
-                  <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900/10 text-slate-700">
-                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12.75 9 17.25 19.5 6.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
-                  </span>
-                </div>
-                <p class="mt-3 text-xs font-medium text-emerald-600" x-text="card.delta"></p>
-              </article>
-            </template>
+          <div x-cloak x-show="error" x-transition class="mt-8 rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p class="font-semibold">Unable to load dashboard metrics.</p>
+                <p class="mt-1 text-rose-600" x-text="error"></p>
+              </div>
+              <button type="button" @click="fetchStats" class="inline-flex items-center gap-2 rounded-full border border-rose-200 bg-white px-4 py-2 text-xs font-semibold text-rose-700 shadow-sm hover:border-rose-300">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 4.5v6h6" stroke-linecap="round" stroke-linejoin="round" /><path d="M3 10.5A9 9 0 0 1 12 3a9 9 0 0 1 9 9" stroke-linecap="round" /></svg>
+                Retry
+              </button>
+            </div>
+          </div>
+
+          <section class="mt-10">
+            <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+              <template x-if="loading">
+                <template x-for="i in 4" :key="`card-skel-${i}`">
+                  <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                    <div class="flex items-center justify-between">
+                      <div class="space-y-3">
+                        <span class="skeleton-line h-3 w-20 rounded"></span>
+                        <span class="skeleton-line h-6 w-24 rounded"></span>
+                      </div>
+                      <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100 text-slate-300">
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12.75 9 17.25 19.5 6.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                      </span>
+                    </div>
+                    <span class="mt-6 block skeleton-line h-3 w-28 rounded"></span>
+                  </article>
+                </template>
+              </template>
+              <template x-if="!loading">
+                <template x-for="card in cards" :key="card.name">
+                  <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                    <div class="flex items-center justify-between">
+                      <div>
+                        <p class="text-xs uppercase tracking-wide text-slate-400" x-text="card.name"></p>
+                        <p class="mt-2 text-3xl font-semibold text-slate-900" x-text="card.value"></p>
+                      </div>
+                      <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900/10 text-slate-700">
+                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12.75 9 17.25 19.5 6.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                      </span>
+                    </div>
+                    <p class="mt-3 text-xs font-medium text-emerald-600" x-text="card.delta"></p>
+                  </article>
+                </template>
+              </template>
+            </div>
           </section>
 
           <section class="mt-10 grid gap-6 lg:grid-cols-5">
@@ -126,7 +159,19 @@
                 </div>
                 <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Updated weekly</span>
               </header>
-              <div class="mt-6"><canvas id="majorChart" aria-label="Bar chart showing students by major" role="img"></canvas></div>
+              <div class="mt-6">
+                <template x-if="loading">
+                  <div class="h-72 rounded-xl border border-slate-200 bg-slate-50/80"></div>
+                </template>
+                <template x-if="!loading && !stats.students_by_major.length">
+                  <div class="flex h-72 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/80 text-sm text-slate-500">
+                    No majors to display yet.
+                  </div>
+                </template>
+                <div x-show="!loading && stats.students_by_major.length" class="relative h-72" x-cloak>
+                  <canvas x-ref="majorCanvas" aria-label="Bar chart showing students by major" role="img"></canvas>
+                </div>
+              </div>
             </article>
             <article class="lg:col-span-2 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
               <header class="flex items-center justify-between">
@@ -136,7 +181,19 @@
                 </div>
                 <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">Rolling 4 terms</span>
               </header>
-              <div class="mt-6"><canvas id="enrollmentChart" aria-label="Line chart showing enrollments per semester" role="img"></canvas></div>
+              <div class="mt-6">
+                <template x-if="loading">
+                  <div class="h-72 rounded-xl border border-slate-200 bg-slate-50/80"></div>
+                </template>
+                <template x-if="!loading && !stats.enrollments_by_semester.length">
+                  <div class="flex h-72 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/80 text-sm text-slate-500">
+                    No enrollment activity recorded.
+                  </div>
+                </template>
+                <div x-show="!loading && stats.enrollments_by_semester.length" class="relative h-72" x-cloak>
+                  <canvas x-ref="enrollmentCanvas" aria-label="Line chart showing enrollments per semester" role="img"></canvas>
+                </div>
+              </div>
             </article>
           </section>
 
@@ -178,49 +235,17 @@
   </div>
 
   <script>
-    const dashboardMock = {
-      students: [
-        { id: 'S-1001', name: 'Asha Patel', major: 'Computer Science' },
-        { id: 'S-1002', name: 'Ethan Wright', major: 'Mathematics' },
-        { id: 'S-1003', name: 'Lina Alvarez', major: 'Biology' },
-        { id: 'S-1004', name: 'Noah Kim', major: 'Computer Science' },
-        { id: 'S-1005', name: 'Maya Chen', major: 'Economics' },
-        { id: 'S-1006', name: 'Gabriel Souza', major: 'Physics' },
-        { id: 'S-1007', name: 'Leah Johnson', major: 'Computer Science' },
-        { id: 'S-1008', name: 'Omar Ali', major: 'Economics' }
-      ],
-      courses: [
-        { id: 'CIS-210', title: 'Data Structures' },
-        { id: 'BIO-120', title: 'Genetics' },
-        { id: 'MTH-240', title: 'Linear Algebra' },
-        { id: 'ECO-201', title: 'Microeconomics' },
-        { id: 'PHY-330', title: 'Quantum Mechanics' },
-        { id: 'CIS-330', title: 'Operating Systems' }
-      ],
-      sections: [
-        { id: 'SEC-101', capacity: 32 },
-        { id: 'SEC-102', capacity: 28 },
-        { id: 'SEC-103', capacity: 24 },
-        { id: 'SEC-104', capacity: 26 },
-        { id: 'SEC-105', capacity: 22 },
-        { id: 'SEC-106', capacity: 18 }
-      ],
-      enrollments: [
-        { semester: '2024 Fall', count: 310 },
-        { semester: '2025 Spring', count: 298 },
-        { semester: '2025 Summer', count: 184 },
-        { semester: '2025 Fall', count: 327 }
-      ]
-    };
-
     document.addEventListener('alpine:init', () => {
       Alpine.data('dashboardPage', () => ({
-        cards: [
-          { name: 'Total students', value: dashboardMock.students.length, delta: '+12% vs LY' },
-          { name: 'Active courses', value: dashboardMock.courses.length, delta: '+3 new this term' },
-          { name: 'Sections this term', value: dashboardMock.sections.length, delta: '92% capacity filled' },
-          { name: 'Enrollments', value: dashboardMock.enrollments.reduce((sum, entry) => sum + entry.count, 0), delta: '+18 since last week' }
-        ],
+        loading: true,
+        error: '',
+        stats: {
+          students_by_major: [],
+          enrollments_by_semester: [],
+          top_courses_by_enrollment: []
+        },
+        majorChart: null,
+        enrollmentChart: null,
         checklist: [
           { step: 1, title: 'Confirm advising rosters', description: 'Finalize assignments for new transfer students.' },
           { step: 2, title: 'Publish midterm grades', description: 'Grades are due Friday at 5pm for 200-level courses.' },
@@ -230,80 +255,184 @@
           { title: 'Review student directory', description: 'Search and manage profiles.', href: '/pages/students.html' },
           { title: 'Update course catalog', description: 'Edit credit hours & descriptions.', href: '/pages/courses.html' },
           { title: 'Coordinate sections', description: 'Assign rooms and instructors.', href: '/pages/sections.html' }
-        ]
+        ],
+        init() {
+          this.fetchStats();
+        },
+        async fetchStats() {
+          this.loading = true;
+          this.error = '';
+          try {
+            const response = await fetch('/api/stats');
+            const payload = await response.json().catch(() => null);
+            if (!response.ok || !payload || typeof payload !== 'object') {
+              const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+              throw new Error(message);
+            }
+            this.stats = {
+              students_by_major: Array.isArray(payload.students_by_major) ? payload.students_by_major : [],
+              enrollments_by_semester: Array.isArray(payload.enrollments_by_semester) ? payload.enrollments_by_semester : [],
+              top_courses_by_enrollment: Array.isArray(payload.top_courses_by_enrollment)
+                ? payload.top_courses_by_enrollment
+                : []
+            };
+            this.$nextTick(() => {
+              this.renderCharts();
+            });
+          } catch (error) {
+            console.error('Failed to load stats', error);
+            this.error = error instanceof Error ? error.message : 'Please refresh and try again.';
+            this.destroyCharts();
+          } finally {
+            this.loading = false;
+          }
+        },
+        get cards() {
+          const studentTotal = this.stats.students_by_major.reduce((sum, item) => sum + (Number(item.count) || 0), 0);
+          const enrollmentTotal = this.stats.enrollments_by_semester.reduce((sum, item) => sum + (Number(item.count) || 0), 0);
+          const semesterCount = this.stats.enrollments_by_semester.length;
+          const majorCount = this.stats.students_by_major.length;
+          const topCourse = this.stats.top_courses_by_enrollment[0] || null;
+          return [
+            {
+              name: 'Total students',
+              value: studentTotal ? this.formatNumber(studentTotal) : '—',
+              delta: majorCount ? `${majorCount} major${majorCount === 1 ? '' : 's'} represented` : 'Awaiting roster'
+            },
+            {
+              name: 'Enrollments logged',
+              value: enrollmentTotal ? this.formatNumber(enrollmentTotal) : '—',
+              delta: semesterCount ? `Across ${semesterCount} semester${semesterCount === 1 ? '' : 's'}` : 'No records yet'
+            },
+            {
+              name: 'Active majors',
+              value: majorCount ? this.formatNumber(majorCount) : '—',
+              delta: studentTotal ? `${this.formatNumber(Math.round(studentTotal / Math.max(majorCount, 1)))} avg per major` : 'Awaiting data'
+            },
+            {
+              name: 'Top course',
+              value: topCourse ? (topCourse.title || topCourse.course_id || '—') : '—',
+              delta: topCourse && topCourse.count ? `${this.formatNumber(topCourse.count)} enrolled` : 'No enrollments logged'
+            }
+          ];
+        },
+        formatNumber(value) {
+          try {
+            return new Intl.NumberFormat('en-US').format(Number(value) || 0);
+          } catch (error) {
+            return String(value);
+          }
+        },
+        destroyCharts() {
+          if (this.majorChart) {
+            this.majorChart.destroy();
+            this.majorChart = null;
+          }
+          if (this.enrollmentChart) {
+            this.enrollmentChart.destroy();
+            this.enrollmentChart = null;
+          }
+        },
+        renderCharts() {
+          this.renderMajorChart();
+          this.renderEnrollmentChart();
+        },
+        renderMajorChart() {
+          const labels = this.stats.students_by_major.map((item) => item.major_dept_id || 'UNKNOWN');
+          const data = this.stats.students_by_major.map((item) => Number(item.count) || 0);
+          if (!labels.length || !this.$refs.majorCanvas) {
+            if (this.majorChart) {
+              this.majorChart.destroy();
+              this.majorChart = null;
+            }
+            return;
+          }
+          if (this.majorChart) {
+            this.majorChart.data.labels = labels;
+            this.majorChart.data.datasets[0].data = data;
+            this.majorChart.update();
+            return;
+          }
+          const ctx = this.$refs.majorCanvas.getContext('2d');
+          if (!ctx) return;
+          this.majorChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels,
+              datasets: [
+                {
+                  label: 'Students',
+                  data,
+                  backgroundColor: '#1e293b'
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false }
+              },
+              scales: {
+                x: { ticks: { color: '#475569' } },
+                y: {
+                  ticks: { color: '#475569' },
+                  beginAtZero: true,
+                  suggestedMax: Math.max(...data, 5) + 2
+                }
+              }
+            }
+          });
+        },
+        renderEnrollmentChart() {
+          const labels = this.stats.enrollments_by_semester.map((item) => item.semester || 'UNKNOWN');
+          const data = this.stats.enrollments_by_semester.map((item) => Number(item.count) || 0);
+          if (!labels.length || !this.$refs.enrollmentCanvas) {
+            if (this.enrollmentChart) {
+              this.enrollmentChart.destroy();
+              this.enrollmentChart = null;
+            }
+            return;
+          }
+          if (this.enrollmentChart) {
+            this.enrollmentChart.data.labels = labels;
+            this.enrollmentChart.data.datasets[0].data = data;
+            this.enrollmentChart.update();
+            return;
+          }
+          const ctx = this.$refs.enrollmentCanvas.getContext('2d');
+          if (!ctx) return;
+          this.enrollmentChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+              labels,
+              datasets: [
+                {
+                  label: 'Enrollments',
+                  data,
+                  fill: false,
+                  borderColor: '#0f172a',
+                  backgroundColor: '#0f172a',
+                  tension: 0.4,
+                  pointRadius: 4,
+                  pointBackgroundColor: '#f97316'
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false }
+              },
+              scales: {
+                x: { ticks: { color: '#475569' } },
+                y: { ticks: { color: '#475569' }, beginAtZero: false }
+              }
+            }
+          });
+        }
       }));
-    });
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const majorCounts = dashboardMock.students.reduce((acc, student) => {
-        acc[student.major] = (acc[student.major] || 0) + 1;
-        return acc;
-      }, {});
-      const majors = Object.keys(majorCounts);
-      const majorValues = majors.map((major) => majorCounts[major]);
-
-      const enrollmentsBySemester = dashboardMock.enrollments;
-
-      const barCtx = document.getElementById('majorChart');
-      if (barCtx) {
-        new Chart(barCtx, {
-          type: 'bar',
-          data: {
-            labels: majors,
-            datasets: [
-              {
-                label: 'Students',
-                data: majorValues,
-                backgroundColor: '#1e293b'
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false }
-            },
-            scales: {
-              x: { ticks: { color: '#475569' } },
-              y: { ticks: { color: '#475569' }, beginAtZero: true, suggestedMax: Math.max(...majorValues, 5) + 2 }
-            }
-          }
-        });
-      }
-
-      const lineCtx = document.getElementById('enrollmentChart');
-      if (lineCtx) {
-        new Chart(lineCtx, {
-          type: 'line',
-          data: {
-            labels: enrollmentsBySemester.map((item) => item.semester),
-            datasets: [
-              {
-                label: 'Enrollments',
-                data: enrollmentsBySemester.map((item) => item.count),
-                fill: false,
-                borderColor: '#0f172a',
-                backgroundColor: '#0f172a',
-                tension: 0.4,
-                pointRadius: 4,
-                pointBackgroundColor: '#f97316'
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false }
-            },
-            scales: {
-              x: { ticks: { color: '#475569' } },
-              y: { ticks: { color: '#475569' }, beginAtZero: false }
-            }
-          }
-        });
-      }
     });
   </script>
 </body>

--- a/frontend/pages/courses.html
+++ b/frontend/pages/courses.html
@@ -88,7 +88,7 @@
               <p class="mt-2 text-slate-600">Browse and curate the academic catalog students can enroll in next term.</p>
             </div>
             <div class="flex flex-wrap gap-3">
-              <button type="button" @click="openModal()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+              <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
                 Add course
               </button>
@@ -131,53 +131,78 @@
               </div>
             </div>
 
-            <div class="mt-8 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-              <template x-if="filteredCourses.length === 0">
-                <div class="sm:col-span-2 xl:col-span-3 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
-                  <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
-                    <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
-                  </span>
-                  <div>
-                    <h3 class="text-lg font-semibold text-slate-900">No courses found</h3>
-                    <p class="mt-1 text-sm text-slate-500">Adjust filters or add a new course to the catalog.</p>
-                  </div>
-                  <button type="button" @click="openModal()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
-                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
-                    Add course
-                  </button>
+            <div class="mt-8">
+              <div x-cloak x-show="loadError" x-transition class="rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+                <p class="font-medium">Unable to load courses.</p>
+                <p class="mt-1 text-rose-600" x-text="loadError"></p>
+              </div>
+
+              <template x-if="loading">
+                <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <template x-for="i in 6" :key="i">
+                    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                      <div class="space-y-4">
+                        <span class="skeleton-line h-5 w-28 rounded"></span>
+                        <div class="space-y-2">
+                          <span class="skeleton-line h-4 w-48 rounded"></span>
+                          <span class="skeleton-line h-3 w-full rounded"></span>
+                          <span class="skeleton-line h-3 w-3/4 rounded"></span>
+                        </div>
+                        <span class="skeleton-line h-4 w-20 rounded"></span>
+                      </div>
+                    </article>
+                  </template>
                 </div>
               </template>
 
-              <template x-for="course in filteredCourses" :key="course.id">
-                <article class="flex flex-col justify-between rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-                  <div class="space-y-3">
-                    <div class="flex items-center justify-between">
-                      <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
-                        <span class="h-2 w-2 rounded-full bg-slate-400"></span>
-                        <span x-text="course.dept_id"></span>
-                      </span>
-                      <span class="text-xs font-semibold text-slate-400" x-text="`${course.credits} credits`"></span>
-                    </div>
+              <div x-cloak x-show="!loading && !loadError" class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                <template x-if="filteredCourses.length === 0">
+                  <div class="sm:col-span-2 xl:col-span-3 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                    <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                      <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
+                    </span>
                     <div>
-                      <h3 class="text-lg font-semibold text-slate-900" x-text="course.title"></h3>
-                      <p class="text-sm text-slate-500" x-text="course.description"></p>
+                      <h3 class="text-lg font-semibold text-slate-900">No courses found</h3>
+                      <p class="mt-1 text-sm text-slate-500">Adjust filters or add a new course to the catalog.</p>
                     </div>
+                    <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                      Add course
+                    </button>
                   </div>
-                  <div class="mt-6 flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
-                    <p class="font-medium text-slate-700" x-text="course.id"></p>
-                    <div class="flex items-center gap-2">
-                      <button type="button" @click="openModal(course)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
-                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
-                        Edit
-                      </button>
-                      <button type="button" @click="removeCourse(course.id)" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50">
-                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
-                        Delete
-                      </button>
+                </template>
+
+                <template x-for="course in filteredCourses" :key="course._id">
+                  <article class="flex flex-col justify-between rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                    <div class="space-y-3">
+                      <div class="flex items-center justify-between">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                          <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                          <span x-text="course.dept_id"></span>
+                        </span>
+                        <span class="text-xs font-semibold text-slate-400" x-text="`${course.credits} credits`"></span>
+                      </div>
+                      <div>
+                        <h3 class="text-lg font-semibold text-slate-900" x-text="course.title"></h3>
+                        <p class="text-sm text-slate-500" x-text="course.description"></p>
+                      </div>
                     </div>
-                  </div>
-                </article>
-              </template>
+                    <div class="mt-6 flex flex-wrap items-center justify-between gap-3 text-xs text-slate-500">
+                      <p class="font-medium text-slate-700" x-text="course._id"></p>
+                      <div class="flex items-center gap-2">
+                        <button type="button" @click="openEdit(course)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
+                          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
+                          Edit
+                        </button>
+                        <button type="button" @click="deleteCourse(course._id)" :disabled="deletingId === course._id" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50">
+                          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
+                          <span x-text="deletingId === course._id ? 'Removing…' : 'Delete'"></span>
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                </template>
+              </div>
             </div>
           </section>
         </div>
@@ -200,8 +225,8 @@
           <div class="relative w-full max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow-xl" x-trap.noscroll="modalOpen" x-transition>
             <header class="flex items-start justify-between gap-3">
               <div>
-                <p class="text-xs uppercase tracking-widest text-slate-400" x-text="editingCourse ? 'Update course' : 'Create course'"></p>
-                <h2 class="text-2xl font-semibold text-slate-900" x-text="editingCourse ? 'Edit course' : 'Add new course'"></h2>
+                <p class="text-xs uppercase tracking-widest text-slate-400" x-text="isEditing ? 'Update course' : 'Create course'"></p>
+                <h2 class="text-2xl font-semibold text-slate-900" x-text="isEditing ? 'Edit course' : 'Add new course'"></h2>
               </div>
               <button type="button" class="rounded-lg border border-transparent p-2 text-slate-400 hover:text-slate-600" @click="closeModal()" aria-label="Close dialog">
                 <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 9l6 6m0-6-6 6" stroke-linecap="round" /></svg>
@@ -210,9 +235,9 @@
             <form class="mt-6 space-y-4" @submit.prevent="saveCourse()">
               <div>
                 <label for="course-id" class="text-sm font-medium text-slate-700">Course code</label>
-                <input id="course-id" type="text" x-model="form.id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. CIS-210" required />
+                <input id="course-id" type="text" x-model="form._id" :disabled="isEditing" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:bg-slate-50" :class="errors._id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. CS101" required />
                 <p class="mt-1 text-xs text-slate-500">Use the registrar approved catalog code.</p>
-                <p x-show="errors.id" x-text="errors.id" class="mt-1 text-xs font-medium text-rose-600"></p>
+                <p x-show="errors._id" x-text="errors._id" class="mt-1 text-xs font-medium text-rose-600"></p>
               </div>
               <div>
                 <label for="course-title" class="text-sm font-medium text-slate-700">Title</label>
@@ -241,10 +266,10 @@
                 <textarea id="course-description" rows="3" x-model="form.description" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="Brief summary of the course"></textarea>
               </div>
               <div class="flex items-center justify-end gap-3 pt-4">
-                <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300" @click="closeModal()">Cancel</button>
-                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300 disabled:opacity-50" @click="closeModal()" :disabled="saving">Cancel</button>
+                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth disabled:opacity-50" :disabled="saving">
                   <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></svg>
-                  Save course
+                  <span x-text="saving ? 'Saving…' : 'Save course'"></span>
                 </button>
               </div>
             </form>
@@ -255,15 +280,6 @@
   </div>
 
   <script>
-    const courseSeed = [
-      { id: 'CIS-210', title: 'Data Structures', credits: 3, dept_id: 'CS', description: 'Foundational algorithms and data abstractions with weekly labs.' },
-      { id: 'CIS-330', title: 'Operating Systems', credits: 4, dept_id: 'CS', description: 'Kernel architecture, scheduling, and concurrency design.' },
-      { id: 'MTH-240', title: 'Linear Algebra', credits: 3, dept_id: 'MATH', description: 'Vector spaces, eigenvalues, and applications to data science.' },
-      { id: 'BIO-120', title: 'Genetics', credits: 4, dept_id: 'BIO', description: 'Fundamentals of DNA replication, transcription, and expression.' },
-      { id: 'ECON-201', title: 'Microeconomics', credits: 3, dept_id: 'ECON', description: 'Consumer theory, firm behavior, and market equilibrium.' },
-      { id: 'PHYS-330', title: 'Quantum Mechanics', credits: 4, dept_id: 'PHYS', description: 'Quantum theory of matter with emphasis on atomic systems.' }
-    ];
-
     const courseDepartments = [
       { id: 'CS', name: 'Computer Science' },
       { id: 'MATH', name: 'Mathematics' },
@@ -278,36 +294,93 @@
         search: '',
         selectedDept: '',
         selectedCredits: '',
-        courses: courseSeed.map((course) => ({ ...course })),
+        loading: true,
+        loadError: '',
+        courses: [],
         departments: courseDepartments,
         modalOpen: false,
-        editingCourse: null,
-        form: { id: '', title: '', credits: 3, dept_id: '', description: '' },
+        isEditing: false,
+        saving: false,
+        deletingId: '',
+        toastTimeout: null,
+        form: { _id: '', title: '', credits: 3, dept_id: '', description: '' },
         errors: {},
         toast: { visible: false, message: '', detail: '', variant: 'success' },
         get filteredCourses() {
+          const term = this.search.trim().toLowerCase();
           return this.courses.filter((course) => {
             const matchesDept = this.selectedDept ? course.dept_id === this.selectedDept : true;
-            const matchesCredits = this.selectedCredits ? Number(course.credits) === Number(this.selectedCredits) : true;
-            const term = this.search.trim().toLowerCase();
+            const matchesCredits = this.selectedCredits
+              ? Number(course.credits) === Number(this.selectedCredits)
+              : true;
             const matchesSearch = term
-              ? [course.title, course.id, course.dept_id].some((value) => (value || '').toLowerCase().includes(term))
+              ? [course.title, course._id, course.dept_id]
+                  .some((value) => String(value || '').toLowerCase().includes(term))
               : true;
             return matchesDept && matchesCredits && matchesSearch;
           });
         },
-        openModal(course = null) {
-          this.editingCourse = course ? { ...course } : null;
-          this.form = course ? { ...course } : { id: '', title: '', credits: 3, dept_id: '', description: '' };
+        init() {
+          this.fetchCourses();
+        },
+        blankForm() {
+          return { _id: '', title: '', credits: 3, dept_id: '', description: '' };
+        },
+        async fetchCourses() {
+          this.loading = true;
+          this.loadError = '';
+          try {
+            const response = await fetch('/api/courses');
+            const payload = await response.json().catch(() => null);
+            if (!response.ok || !Array.isArray(payload)) {
+              const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+              throw new Error(message);
+            }
+            this.courses = payload.map((course) => ({
+              _id: course._id ?? '',
+              title: course.title ?? '',
+              dept_id: course.dept_id ?? '',
+              credits: Number.isFinite(Number(course.credits)) ? Number(course.credits) : '',
+              description: course.description ?? ''
+            }));
+          } catch (error) {
+            console.error('Failed to load courses', error);
+            this.courses = [];
+            this.loadError = error instanceof Error ? error.message : 'Please refresh and try again.';
+            this.showToast('Unable to load courses.', 'error', 'Check your network connection.');
+          } finally {
+            this.loading = false;
+          }
+        },
+        openCreate() {
+          this.isEditing = false;
+          this.form = this.blankForm();
           this.errors = {};
+          this.saving = false;
+          this.modalOpen = true;
+        },
+        openEdit(course) {
+          this.isEditing = true;
+          this.form = {
+            _id: course._id,
+            title: course.title,
+            dept_id: course.dept_id,
+            credits: course.credits || 0,
+            description: course.description || ''
+          };
+          this.errors = {};
+          this.saving = false;
           this.modalOpen = true;
         },
         closeModal() {
+          if (this.saving) return;
           this.modalOpen = false;
+          this.form = this.blankForm();
+          this.errors = {};
         },
         validate() {
           const nextErrors = {};
-          if (!this.form.id.trim()) nextErrors.id = 'Course code is required.';
+          if (!this.form._id.trim()) nextErrors._id = 'Course code is required.';
           if (!this.form.title.trim()) nextErrors.title = 'Course title is required.';
           if (!this.form.dept_id) nextErrors.dept_id = 'Select a department.';
           if (this.form.credits === '' || Number.isNaN(Number(this.form.credits)) || Number(this.form.credits) <= 0) {
@@ -316,38 +389,99 @@
           this.errors = nextErrors;
           return Object.keys(nextErrors).length === 0;
         },
-        saveCourse() {
+        async saveCourse() {
           if (!this.validate()) {
             this.showToast('Please review the highlighted fields.', 'error', 'Invalid course details');
             return;
           }
-          if (this.editingCourse) {
-            const index = this.courses.findIndex((course) => course.id === this.editingCourse.id);
-            if (index !== -1) {
-              this.courses.splice(index, 1, { ...this.form });
-              this.showToast('Course updated successfully.', 'success', 'Catalog entry saved.');
-            }
-          } else {
-            if (this.courses.some((course) => course.id === this.form.id)) {
-              this.errors.id = 'A course with this code already exists.';
-              this.showToast('Duplicate course code.', 'error', 'Use a unique catalog code.');
+
+          this.saving = true;
+          const payload = {
+            _id: this.form._id.trim(),
+            title: this.form.title.trim(),
+            dept_id: this.form.dept_id,
+            credits: this.form.credits,
+            description: this.form.description.trim()
+          };
+
+          const method = this.isEditing ? 'PUT' : 'POST';
+          const url = this.isEditing
+            ? `/api/courses/${encodeURIComponent(this.form._id)}`
+            : '/api/courses';
+
+          if (this.isEditing) {
+            delete payload._id;
+          }
+
+          try {
+            const response = await fetch(url, {
+              method,
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload)
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result) {
+              const details = (result && result.details) || {};
+              this.errors = details;
+              const detailMessage =
+                details.title || details._id || details.dept_id || Object.values(details)[0] || '';
+              this.showToast((result && result.error) || 'Unable to save course.', 'error', detailMessage);
               return;
             }
-            this.courses = [...this.courses, { ...this.form }];
-            this.showToast('Course added to catalog.', 'success', 'Publish changes when ready.');
+
+            await this.fetchCourses();
+            this.closeModal();
+            this.showToast(
+              this.isEditing ? 'Course updated successfully.' : 'Course added to catalog.',
+              'success',
+              this.isEditing ? 'Catalog entry saved.' : 'Course is now available to sections.'
+            );
+          } catch (error) {
+            console.error('Failed to save course', error);
+            this.showToast('Unable to save course.', 'error', 'Check your network connection.');
+          } finally {
+            this.saving = false;
           }
-          this.closeModal();
         },
-        removeCourse(id) {
+        async deleteCourse(id) {
           if (!window.confirm('Remove this course from the catalog?')) {
             return;
           }
-          this.courses = this.courses.filter((course) => course.id !== id);
-          this.showToast('Course removed.', 'success', 'Students will no longer see this course.');
+          this.deletingId = id;
+          try {
+            const response = await fetch(`/api/courses/${encodeURIComponent(id)}`, {
+              method: 'DELETE'
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result || !result.deleted) {
+              this.showToast(
+                (result && result.error) || 'Unable to delete course.',
+                'error',
+                'Please try again in a moment.'
+              );
+              return;
+            }
+
+            this.courses = this.courses.filter((course) => course._id !== id);
+            const detail = result.active_sections
+              ? `${result.active_sections} section(s) remain linked to this course.`
+              : 'Course removed from the catalog.';
+            this.showToast('Course removed.', 'success', detail);
+          } catch (error) {
+            console.error('Failed to delete course', error);
+            this.showToast('Unable to delete course.', 'error', 'Check your network connection.');
+          } finally {
+            this.deletingId = '';
+          }
         },
         showToast(message, variant = 'success', detail = '') {
+          if (this.toastTimeout) {
+            clearTimeout(this.toastTimeout);
+          }
           this.toast = { visible: true, message, variant, detail };
-          setTimeout(() => {
+          this.toastTimeout = setTimeout(() => {
             this.toast.visible = false;
           }, 3200);
         }

--- a/frontend/pages/enrollments.html
+++ b/frontend/pages/enrollments.html
@@ -88,9 +88,9 @@
               <p class="mt-2 text-slate-600">Monitor performance, identify grade risks, and manage grading deadlines.</p>
             </div>
             <div class="flex flex-wrap gap-3">
-              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
+              <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:border-slate-300">
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12" stroke-linecap="round" /><path d="M6 12h12" stroke-linecap="round" /></svg>
-                Create report
+                Add enrollment
               </button>
               <button type="button" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 5.25 15.75 12 9 18.75" stroke-linecap="round" stroke-linejoin="round" /></svg>
@@ -132,106 +132,271 @@
               </div>
             </div>
 
-            <div class="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-xs text-slate-500">
-              <div class="flex items-center gap-2">
-                <input id="bulk-select" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-300" disabled />
-                <label for="bulk-select" class="font-medium text-slate-500">Bulk select (coming soon)</label>
+            <div class="mt-6">
+              <div x-cloak x-show="loadError" x-transition class="rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+                <p class="font-medium">Unable to load enrollments.</p>
+                <p class="mt-1 text-rose-600" x-text="loadError"></p>
               </div>
-              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-400" disabled>
-                <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 16.5h15" stroke-linecap="round" /><path d="M4.5 7.5h15" stroke-linecap="round" /></svg>
-                Apply bulk actions
-              </button>
-            </div>
 
-            <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200">
-              <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
-                  <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
-                    <tr>
-                      <th scope="col" class="px-4 py-3 font-semibold">Student</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Section</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Midterm</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Final</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Bonus</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Letter</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-slate-100 bg-white">
-                    <template x-for="record in filteredEnrollments" :key="record.id">
-                      <tr class="hover:bg-slate-50">
-                        <td class="px-4 py-3">
-                          <div class="font-medium text-slate-900" x-text="record.student_name"></div>
-                          <p class="text-xs text-slate-500" x-text="record.student_id"></p>
-                        </td>
-                        <td class="px-4 py-3">
-                          <div class="font-medium text-slate-900" x-text="record.section"></div>
-                          <p class="text-xs text-slate-500" x-text="record.course"></p>
-                        </td>
-                        <td class="px-4 py-3">
-                          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
-                            <span class="h-2 w-2 rounded-full bg-slate-400"></span>
-                            <span x-text="record.semester"></span>
-                          </span>
-                        </td>
-                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.midterm"></td>
-                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.final"></td>
-                        <td class="px-4 py-3 text-sm text-slate-700" x-text="record.bonus"></td>
-                        <td class="px-4 py-3">
-                          <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" :class="badgeClass(record.letter)">
-                            <span x-text="record.letter"></span>
-                            <span class="hidden sm:inline" x-text="record.status"></span>
-                          </span>
-                        </td>
-                      </tr>
-                    </template>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-            <template x-if="filteredEnrollments.length === 0">
-              <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
-                  <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
-                </span>
-                <div>
-                  <h3 class="text-lg font-semibold text-slate-900">No enrollment records</h3>
-                  <p class="mt-1 text-sm text-slate-500">Broaden your filters or refresh after instructors submit grades.</p>
+              <template x-if="loading">
+                <div class="overflow-hidden rounded-2xl border border-slate-200">
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                      <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                        <tr>
+                          <th scope="col" class="px-4 py-3 font-semibold">Student</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Midterm</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Final</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Bonus</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Letter</th>
+                          <th scope="col" class="px-4 py-3 font-semibold text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-100 bg-white">
+                        <template x-for="i in 6" :key="i">
+                          <tr>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-40 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-36 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-20 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-16 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-16 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-16 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-12 rounded"></span></td>
+                            <td class="px-4 py-3 text-right"><span class="skeleton-line h-4 w-24 rounded ml-auto block"></span></td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
-            </template>
+              </template>
+
+              <template x-if="!loading && !loadError && filteredEnrollments.length">
+                <div class="overflow-hidden rounded-2xl border border-slate-200">
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                      <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                        <tr>
+                          <th scope="col" class="px-4 py-3 font-semibold">Student</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Midterm</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Final</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Bonus</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Letter</th>
+                          <th scope="col" class="px-4 py-3 font-semibold text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-100 bg-white">
+                        <template x-for="record in filteredEnrollments" :key="record._id">
+                          <tr class="hover:bg-slate-50">
+                            <td class="px-4 py-3">
+                              <div class="font-medium text-slate-900" x-text="record.student_name || record.student_id"></div>
+                              <p class="text-xs text-slate-500" x-text="record.student_id"></p>
+                            </td>
+                            <td class="px-4 py-3">
+                              <div class="font-medium text-slate-900" x-text="record.course_title || record.section_id"></div>
+                              <p class="text-xs text-slate-500" x-text="record.section_label"></p>
+                            </td>
+                            <td class="px-4 py-3">
+                              <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                                <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                                <span x-text="record.semester"></span>
+                              </span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-slate-700" x-text="formatScore(record.midterm)"></td>
+                            <td class="px-4 py-3 text-sm text-slate-700" x-text="formatScore(record.final)"></td>
+                            <td class="px-4 py-3 text-sm text-slate-700" x-text="formatScore(record.bonus)"></td>
+                            <td class="px-4 py-3">
+                              <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" :class="badgeClass(record.letter)">
+                                <span x-text="record.letter || '—'"></span>
+                                <span class="hidden sm:inline" x-text="letterStatus(record.letter)"></span>
+                              </span>
+                            </td>
+                            <td class="px-4 py-3 text-right">
+                              <div class="inline-flex items-center gap-2">
+                                <button type="button" @click="openEdit(record)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
+                                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
+                                  Edit
+                                </button>
+                                <button type="button" @click="deleteEnrollment(record._id)" :disabled="deletingId === record._id" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50">
+                                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
+                                  <span x-text="deletingId === record._id ? 'Removing…' : 'Delete'"></span>
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="!loading && !loadError && filteredEnrollments.length === 0">
+                <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                  <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                    <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+                  </span>
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-900">No enrollment records</h3>
+                    <p class="mt-1 text-sm text-slate-500">Broaden your filters or refresh after instructors submit grades.</p>
+                  </div>
+                </div>
+              </template>
+            </div>
           </section>
         </div>
       </main>
     </div>
   </div>
 
-  <script>
-    const enrollmentSeed = [
-      { id: 'ENR-1', student_id: 'S-1001', student_name: 'Asha Patel', section: 'SEC-101', course: 'Data Structures', semester: '2025 Spring', midterm: 88, final: 93, bonus: 5, letter: 'A', status: 'Honors' },
-      { id: 'ENR-2', student_id: 'S-1002', student_name: 'Ethan Wright', section: 'SEC-103', course: 'Linear Algebra', semester: '2025 Spring', midterm: 76, final: 82, bonus: 2, letter: 'B', status: 'Passing' },
-      { id: 'ENR-3', student_id: 'S-1003', student_name: 'Lina Alvarez', section: 'SEC-104', course: 'Genetics', semester: '2025 Summer', midterm: 91, final: 89, bonus: 4, letter: 'A-', status: 'Dean list' },
-      { id: 'ENR-4', student_id: 'S-1004', student_name: 'Noah Kim', section: 'SEC-102', course: 'Operating Systems', semester: '2025 Spring', midterm: 68, final: 75, bonus: 3, letter: 'B-', status: 'Coaching' },
-      { id: 'ENR-5', student_id: 'S-1005', student_name: 'Maya Chen', section: 'SEC-105', course: 'Microeconomics', semester: '2025 Fall', midterm: 95, final: 97, bonus: 4, letter: 'A', status: 'Honors' },
-      { id: 'ENR-6', student_id: 'S-1006', student_name: 'Gabriel Souza', section: 'SEC-106', course: 'Quantum Mechanics', semester: '2025 Fall', midterm: 84, final: 80, bonus: 1, letter: 'B', status: 'Passing' },
-      { id: 'ENR-7', student_id: 'S-1007', student_name: 'Leah Johnson', section: 'SEC-101', course: 'Data Structures', semester: '2025 Spring', midterm: 92, final: 94, bonus: 3, letter: 'A', status: 'Honors' },
-      { id: 'ENR-8', student_id: 'S-1008', student_name: 'Omar Ali', section: 'SEC-105', course: 'Microeconomics', semester: '2025 Fall', midterm: 71, final: 78, bonus: 2, letter: 'B-', status: 'Coaching' },
-      { id: 'ENR-9', student_id: 'S-1009', student_name: 'Jules Laurent', section: 'SEC-107', course: 'Managerial Finance', semester: '2025 Fall', midterm: 66, final: 70, bonus: 0, letter: 'C+', status: 'Watch' },
-      { id: 'ENR-10', student_id: 'S-1010', student_name: 'Sara Ito', section: 'SEC-104', course: 'Genetics', semester: '2025 Summer', midterm: 89, final: 88, bonus: 2, letter: 'A-', status: 'Dean list' }
-    ];
+  <div x-cloak x-show="toast.visible" x-transition class="fixed top-4 right-4 z-50 w-full max-w-sm rounded-xl border px-4 py-3 shadow-lg" :class="toast.variant === 'success' ? 'border-emerald-200 bg-emerald-50/90 text-emerald-800' : 'border-rose-200 bg-rose-50/90 text-rose-700'" role="status" aria-live="polite">
+    <div class="flex items-start gap-3">
+      <span class="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full" :class="toast.variant === 'success' ? 'bg-emerald-600 text-white' : 'bg-rose-600 text-white'">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <template x-if="toast.variant === 'success'"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></template>
+          <template x-if="toast.variant !== 'success'"><path d="M15 9 9 15m0-6 6 6" stroke-linecap="round" stroke-linejoin="round" /></template>
+        </svg>
+      </span>
+      <div>
+        <p class="text-sm font-semibold" x-text="toast.message"></p>
+        <p class="text-xs text-slate-500" x-text="toast.detail"></p>
+      </div>
+      <button type="button" class="ml-auto text-xs font-medium text-slate-500 hover:text-slate-700" @click="toast.visible = false">Dismiss</button>
+    </div>
+  </div>
 
+  <div x-cloak x-show="modalOpen" class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6" role="dialog" aria-modal="true">
+    <div class="absolute inset-0 bg-slate-900/40" @click="closeModal()"></div>
+    <div class="relative w-full max-w-2xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl" x-trap.noscroll="modalOpen" x-transition>
+      <header class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-xs uppercase tracking-widest text-slate-400" x-text="isEditing ? 'Update enrollment' : 'Create enrollment'"></p>
+          <h2 class="text-2xl font-semibold text-slate-900" x-text="isEditing ? 'Edit enrollment' : 'Add new enrollment'"></h2>
+        </div>
+        <button type="button" class="rounded-lg border border-transparent p-2 text-slate-400 hover:text-slate-600" @click="closeModal()" aria-label="Close dialog">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 9l6 6m0-6-6 6" stroke-linecap="round" /></svg>
+        </button>
+      </header>
+
+      <form class="mt-6 space-y-5" @submit.prevent="saveEnrollment()">
+        <div class="grid gap-5 sm:grid-cols-2">
+          <div>
+            <label for="enrollment-student" class="text-sm font-medium text-slate-700">Student</label>
+            <select id="enrollment-student" x-model="form.student_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.student_id ? 'border-rose-300' : 'border-slate-200'" required>
+              <option value="" disabled>Select student</option>
+              <template x-for="student in studentOptions" :key="student._id">
+                <option :value="student._id" x-text="`${student.full_name} (${student._id})`"></option>
+              </template>
+            </select>
+            <p class="mt-1 text-xs text-slate-500" x-show="!studentOptions.length">Load students from the roster to enable selection.</p>
+            <p x-show="errors.student_id" x-text="errors.student_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="enrollment-section" class="text-sm font-medium text-slate-700">Section</label>
+            <select id="enrollment-section" x-model="form.section_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.section_id ? 'border-rose-300' : 'border-slate-200'" required @change="syncSemester()">
+              <option value="" disabled>Select section</option>
+              <template x-for="section in sectionOptions" :key="section._id">
+                <option :value="section._id" x-text="section.label"></option>
+              </template>
+            </select>
+            <p class="mt-1 text-xs text-slate-500" x-show="currentSectionInfo" x-text="currentSectionInfo"></p>
+            <p x-show="errors.section_id" x-text="errors.section_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+        </div>
+
+        <div class="grid gap-5 sm:grid-cols-3">
+          <div>
+            <label for="enrollment-semester" class="text-sm font-medium text-slate-700">Semester</label>
+            <input id="enrollment-semester" type="text" x-model="form.semester" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.semester ? 'border-rose-300' : 'border-slate-200'" placeholder="2025A" required />
+            <p x-show="errors.semester" x-text="errors.semester" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="enrollment-midterm" class="text-sm font-medium text-slate-700">Midterm</label>
+            <input id="enrollment-midterm" type="number" step="0.1" x-model.number="form.midterm" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.midterm ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. 88" />
+            <p x-show="errors.midterm" x-text="errors.midterm" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="enrollment-final" class="text-sm font-medium text-slate-700">Final</label>
+            <input id="enrollment-final" type="number" step="0.1" x-model.number="form.final" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.final ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. 92" />
+            <p x-show="errors.final" x-text="errors.final" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+        </div>
+
+        <div class="grid gap-5 sm:grid-cols-3">
+          <div>
+            <label for="enrollment-bonus" class="text-sm font-medium text-slate-700">Bonus</label>
+            <input id="enrollment-bonus" type="number" step="0.1" x-model.number="form.bonus" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.bonus ? 'border-rose-300' : 'border-slate-200'" placeholder="Optional" />
+            <p x-show="errors.bonus" x-text="errors.bonus" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label class="text-sm font-medium text-slate-700">Letter grade</label>
+            <div class="mt-1 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700">
+              <span x-text="form.letter || '—'"></span>
+              <span class="text-xs text-slate-500" x-text="currentLetterPreview ? `Preview: ${currentLetterPreview}` : 'Preview unavailable'" ></span>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-end gap-3 pt-2">
+          <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300 disabled:opacity-50" @click="closeModal()" :disabled="saving">Cancel</button>
+          <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth disabled:opacity-50" :disabled="saving">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+            <span x-text="saving ? 'Saving…' : 'Save enrollment'"></span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
     document.addEventListener('alpine:init', () => {
       Alpine.data('enrollmentsPage', () => ({
-        enrollments: enrollmentSeed.map((record) => ({ ...record })),
+        enrollments: [],
+        students: [],
+        sections: [],
+        loading: true,
+        loadError: '',
         search: '',
         selectedSemester: '',
         selectedLetter: '',
+        modalOpen: false,
+        isEditing: false,
+        saving: false,
+        deletingId: '',
+        toastTimeout: null,
+        toast: { visible: false, message: '', detail: '', variant: 'success' },
+        form: {
+          _id: '',
+          student_id: '',
+          section_id: '',
+          semester: '',
+          midterm: '',
+          final: '',
+          bonus: '',
+          letter: ''
+        },
+        errors: {},
+        get studentOptions() {
+          return [...this.students].sort((a, b) => a.full_name.localeCompare(b.full_name));
+        },
+        get sectionOptions() {
+          return [...this.sections].sort((a, b) => a.label.localeCompare(b.label));
+        },
+        get sectionMap() {
+          return this.sections.reduce((acc, section) => {
+            acc[section._id] = section;
+            return acc;
+          }, {});
+        },
         get semesters() {
-          return [...new Set(this.enrollments.map((record) => record.semester))];
+          return [...new Set(this.enrollments.map((record) => record.semester).filter(Boolean))].sort();
         },
         get letters() {
-          return [...new Set(this.enrollments.map((record) => record.letter))];
+          return [...new Set(this.enrollments.map((record) => record.letter).filter(Boolean))].sort();
         },
         get filteredEnrollments() {
           const term = this.search.trim().toLowerCase();
@@ -239,22 +404,333 @@
             const matchesSemester = this.selectedSemester ? record.semester === this.selectedSemester : true;
             const matchesLetter = this.selectedLetter ? record.letter === this.selectedLetter : true;
             const matchesSearch = term
-              ? [record.student_name, record.student_id, record.section, record.course].some((value) =>
-                  (value || '').toLowerCase().includes(term)
-                )
+              ? [record.student_name, record.student_id, record.section_label, record.course_title]
+                  .some((value) => String(value || '').toLowerCase().includes(term))
               : true;
             return matchesSemester && matchesLetter && matchesSearch;
           });
+        },
+        get currentSectionInfo() {
+          const section = this.sectionMap[this.form.section_id];
+          if (!section) return '';
+          const parts = [section.title];
+          if (section.semester) parts.push(section.semester);
+          if (section.section_no) parts.push(`Sec ${section.section_no}`);
+          return parts.join(' • ');
+        },
+        get currentLetterPreview() {
+          return this.calculateLetter(this.form.midterm, this.form.final, this.form.bonus);
+        },
+        init() {
+          this.loadData();
+        },
+        async loadData() {
+          this.loading = true;
+          this.loadError = '';
+          try {
+            const [enrollments, students, sections] = await Promise.all([
+              this.requestEnrollments(),
+              this.requestStudents().catch((error) => {
+                console.error('Failed to load students', error);
+                this.showToast('Unable to load student list.', 'error', 'Student dropdown may be incomplete.');
+                return [];
+              }),
+              this.requestSections().catch((error) => {
+                console.error('Failed to load sections', error);
+                this.showToast('Unable to load sections.', 'error', 'Section dropdown may be incomplete.');
+                return [];
+              })
+            ]);
+            this.enrollments = enrollments;
+            this.students = students;
+            this.sections = sections;
+          } catch (error) {
+            console.error('Failed to load enrollments', error);
+            this.enrollments = [];
+            this.loadError = error instanceof Error ? error.message : 'Please refresh and try again.';
+            this.showToast('Unable to load enrollments.', 'error', 'Check your network connection.');
+          } finally {
+            this.loading = false;
+          }
+        },
+        async requestEnrollments() {
+          const response = await fetch('/api/enrollments');
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !Array.isArray(payload)) {
+            const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          return payload.map((record) => ({
+            _id: record._id ?? `${record.student_id}:${record.section_id}`,
+            student_id: record.student_id ?? '',
+            student_name: record.student_name ?? '',
+            section_id: record.section_id ?? '',
+            section_label: record.section_no ? `${record.section_id} · Sec ${record.section_no}` : record.section_id ?? '',
+            course_title: record.course_title ?? '',
+            semester: record.semester ?? '',
+            midterm: record.midterm != null ? Number(record.midterm) : '',
+            final: record.final != null ? Number(record.final) : '',
+            bonus: record.bonus != null ? Number(record.bonus) : '',
+            letter: record.letter ?? ''
+          }));
+        },
+        async requestStudents() {
+          const response = await fetch('/api/students?limit=500');
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !Array.isArray(payload)) {
+            const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          return payload.map((student) => ({
+            _id: student._id ?? '',
+            full_name: student.full_name ?? student._id ?? ''
+          }));
+        },
+        async requestSections() {
+          const response = await fetch('/api/sections');
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !Array.isArray(payload)) {
+            const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          return payload.map((section) => ({
+            _id: section._id ?? '',
+            title: section.course_title ?? section.course_id ?? '',
+            semester: section.semester ?? '',
+            section_no: section.section_no ?? '',
+            label: section.course_title
+              ? `${section.course_title} (${section._id})`
+              : section._id ?? ''
+          }));
+        },
+        async refreshEnrollments() {
+          this.enrollments = await this.requestEnrollments();
+        },
+        openCreate() {
+          this.isEditing = false;
+          this.form = {
+            _id: '',
+            student_id: '',
+            section_id: '',
+            semester: '',
+            midterm: '',
+            final: '',
+            bonus: '',
+            letter: ''
+          };
+          this.errors = {};
+          this.saving = false;
+          this.modalOpen = true;
+        },
+        openEdit(record) {
+          this.isEditing = true;
+          this.form = {
+            _id: record._id,
+            student_id: record.student_id,
+            section_id: record.section_id,
+            semester: record.semester,
+            midterm: record.midterm === '' ? '' : Number(record.midterm),
+            final: record.final === '' ? '' : Number(record.final),
+            bonus: record.bonus === '' ? '' : Number(record.bonus),
+            letter: record.letter || ''
+          };
+          this.errors = {};
+          this.saving = false;
+          this.modalOpen = true;
+        },
+        closeModal() {
+          if (this.saving) return;
+          this.modalOpen = false;
+          this.form = {
+            _id: '',
+            student_id: '',
+            section_id: '',
+            semester: '',
+            midterm: '',
+            final: '',
+            bonus: '',
+            letter: ''
+          };
+          this.errors = {};
+        },
+        syncSemester() {
+          const section = this.sectionMap[this.form.section_id];
+          if (section && section.semester) {
+            this.form.semester = section.semester;
+          }
+        },
+        validate() {
+          const nextErrors = {};
+          if (!this.form.student_id) nextErrors.student_id = 'Select a student.';
+          if (!this.form.section_id) nextErrors.section_id = 'Select a section.';
+          if (!this.form.semester.trim()) nextErrors.semester = 'Semester is required.';
+          if (this.form.midterm !== '' && Number.isNaN(Number(this.form.midterm))) {
+            nextErrors.midterm = 'Midterm must be a number.';
+          }
+          if (this.form.final !== '' && Number.isNaN(Number(this.form.final))) {
+            nextErrors.final = 'Final must be a number.';
+          }
+          if (this.form.bonus !== '' && Number.isNaN(Number(this.form.bonus))) {
+            nextErrors.bonus = 'Bonus must be a number.';
+          }
+          this.errors = nextErrors;
+          return Object.keys(nextErrors).length === 0;
+        },
+        buildPayload() {
+          const payload = {
+            student_id: this.form.student_id,
+            section_id: this.form.section_id,
+            semester: this.form.semester.trim().toUpperCase(),
+            midterm: this.form.midterm === '' ? null : Number(this.form.midterm),
+            final: this.form.final === '' ? null : Number(this.form.final),
+            bonus: this.form.bonus === '' ? null : Number(this.form.bonus)
+          };
+          return payload;
+        },
+        async saveEnrollment() {
+          if (!this.validate()) {
+            this.showToast('Please review the highlighted fields.', 'error', 'Missing required information.');
+            return;
+          }
+
+          this.saving = true;
+          const payload = this.buildPayload();
+          const method = this.isEditing ? 'PUT' : 'POST';
+          const url = this.isEditing
+            ? `/api/enrollments/${encodeURIComponent(this.form._id)}`
+            : '/api/enrollments';
+
+          try {
+            const response = await fetch(url, {
+              method,
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload)
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result) {
+              const details = (result && result.details) || {};
+              this.errors = details;
+              const detailMessage =
+                details.student_id ||
+                details.section_id ||
+                details.semester ||
+                Object.values(details)[0] || '';
+              this.showToast((result && result.error) || 'Unable to save enrollment.', 'error', detailMessage);
+              return;
+            }
+
+            await this.refreshEnrollments();
+            this.closeModal();
+            this.showToast(
+              this.isEditing ? 'Enrollment updated successfully.' : 'Enrollment created successfully.',
+              'success',
+              result.letter ? `Assigned letter grade: ${result.letter}` : ''
+            );
+          } catch (error) {
+            console.error('Failed to save enrollment', error);
+            this.showToast('Unable to save enrollment.', 'error', 'Check your network connection.');
+          } finally {
+            this.saving = false;
+          }
+        },
+        async deleteEnrollment(id) {
+          if (!window.confirm('Remove this enrollment record?')) {
+            return;
+          }
+
+          this.deletingId = id;
+          try {
+            const response = await fetch(`/api/enrollments/${encodeURIComponent(id)}`, {
+              method: 'DELETE'
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result || !result.deleted) {
+              this.showToast(
+                (result && result.error) || 'Unable to delete enrollment.',
+                'error',
+                'Please try again in a moment.'
+              );
+              return;
+            }
+
+            this.enrollments = this.enrollments.filter((record) => record._id !== id);
+            this.showToast('Enrollment removed.', 'success', 'Student no longer appears in this section.');
+          } catch (error) {
+            console.error('Failed to delete enrollment', error);
+            this.showToast('Unable to delete enrollment.', 'error', 'Check your network connection.');
+          } finally {
+            this.deletingId = '';
+          }
         },
         badgeClass(letter) {
           const palette = {
             A: 'bg-emerald-100 text-emerald-700',
             'A-': 'bg-emerald-50 text-emerald-700',
-            B: 'bg-sky-100 text-sky-700',
-            'B-': 'bg-sky-50 text-sky-700',
-            'C+': 'bg-amber-100 text-amber-800'
+            'B+': 'bg-sky-100 text-sky-700',
+            B: 'bg-sky-50 text-sky-700',
+            'B-': 'bg-blue-50 text-blue-700',
+            'C+': 'bg-amber-100 text-amber-800',
+            C: 'bg-amber-50 text-amber-700',
+            'D+': 'bg-rose-100 text-rose-700',
+            D: 'bg-rose-50 text-rose-700',
+            F: 'bg-rose-100 text-rose-700'
           };
           return palette[letter] || 'bg-slate-100 text-slate-700';
+        },
+        letterStatus(letter) {
+          if (!letter) return 'Pending';
+          if (letter.startsWith('A')) return 'Honors';
+          if (letter.startsWith('B')) return 'On track';
+          if (letter.startsWith('C')) return 'Watch';
+          if (letter.startsWith('D')) return 'At risk';
+          if (letter === 'F') return 'Failing';
+          return 'Recorded';
+        },
+        formatScore(value) {
+          if (value === '' || value === null || Number.isNaN(value)) return '—';
+          const numberValue = Number(value);
+          return Number.isInteger(numberValue) ? numberValue : numberValue.toFixed(1);
+        },
+        calculateLetter(midterm, final, bonus) {
+          const mid = midterm === '' || midterm === null ? null : Number(midterm);
+          const fin = final === '' || final === null ? null : Number(final);
+          const extra = bonus === '' || bonus === null ? 0 : Number(bonus);
+          const scores = [];
+          if (mid != null && !Number.isNaN(mid)) scores.push({ score: mid, weight: 0.4 });
+          if (fin != null && !Number.isNaN(fin)) scores.push({ score: fin, weight: 0.6 });
+          if (!scores.length) return '';
+          let totalWeight = scores.reduce((sum, entry) => sum + entry.weight, 0);
+          if (totalWeight === 0) return '';
+          let weighted = scores.reduce((sum, entry) => sum + entry.score * entry.weight, 0) / totalWeight;
+          weighted = Math.max(0, Math.min(100, weighted + extra));
+          const scale = [
+            { min: 97, grade: 'A+' },
+            { min: 93, grade: 'A' },
+            { min: 90, grade: 'A-' },
+            { min: 87, grade: 'B+' },
+            { min: 83, grade: 'B' },
+            { min: 80, grade: 'B-' },
+            { min: 77, grade: 'C+' },
+            { min: 73, grade: 'C' },
+            { min: 70, grade: 'C-' },
+            { min: 67, grade: 'D+' },
+            { min: 63, grade: 'D' },
+            { min: 60, grade: 'D-' },
+            { min: 0, grade: 'F' }
+          ];
+          const match = scale.find((entry) => weighted >= entry.min);
+          return match ? match.grade : '';
+        },
+        showToast(message, variant = 'success', detail = '') {
+          if (this.toastTimeout) {
+            clearTimeout(this.toastTimeout);
+          }
+          this.toast = { visible: true, message, variant, detail };
+          this.toastTimeout = setTimeout(() => {
+            this.toast.visible = false;
+          }, 3200);
         }
       }));
     });

--- a/frontend/pages/sections.html
+++ b/frontend/pages/sections.html
@@ -92,7 +92,7 @@
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 7.5h13.5" stroke-linecap="round" /><path d="M5.25 12h13.5" stroke-linecap="round" /><path d="M5.25 16.5h13.5" stroke-linecap="round" /></svg>
                 Export plan
               </button>
-              <button type="button" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+              <button type="button" @click="openCreate()" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
                 New section
               </button>
@@ -102,117 +102,538 @@
           <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="grid gap-4 md:grid-cols-3">
               <div class="md:col-span-2">
-                <label for="section-search" class="text-sm font-medium text-slate-700">Search sections</label>
+                <label for="section-course-filter" class="text-sm font-medium text-slate-700">Course</label>
                 <div class="mt-1 relative">
                   <span class="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="6" /><path d="m17 17 3.5 3.5" stroke-linecap="round" /></svg>
                   </span>
-                  <input id="section-search" type="search" x-model="search" placeholder="Search by course, instructor, or room" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
+                  <input id="section-course-filter" type="search" x-model="courseFilter" placeholder="Search by course title or ID" class="w-full rounded-xl border border-slate-200 bg-white py-2 pl-10 pr-3 text-sm text-slate-700 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" />
                 </div>
+                <p class="mt-2 text-xs text-slate-500">Filter sections by matching course title or catalog ID.</p>
               </div>
               <div>
                 <label for="semester-filter" class="text-sm font-medium text-slate-700">Semester</label>
                 <select id="semester-filter" x-model="selectedSemester" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200">
                   <option value="">All semesters</option>
                   <template x-for="semester in semesters" :key="semester">
-                    <option x-text="semester"></option>
+                    <option :value="semester" x-text="semester"></option>
                   </template>
                 </select>
               </div>
             </div>
 
-            <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200">
-              <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
-                  <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
-                    <tr>
-                      <th scope="col" class="px-4 py-3 font-semibold">Section</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Course</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Instructor</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Capacity</th>
-                      <th scope="col" class="px-4 py-3 font-semibold">Room</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-slate-100 bg-white">
-                    <template x-for="section in filteredSections" :key="section.id">
-                      <tr class="hover:bg-slate-50">
-                        <td class="px-4 py-3 font-mono text-xs text-slate-500" x-text="section.id"></td>
-                        <td class="px-4 py-3">
-                          <div class="font-medium text-slate-900" x-text="section.course_title"></div>
-                          <p class="text-xs text-slate-500" x-text="section.course_id"></p>
-                        </td>
-                        <td class="px-4 py-3">
-                          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
-                            <span class="h-2 w-2 rounded-full bg-slate-400"></span>
-                            <span x-text="section.semester"></span>
-                          </span>
-                        </td>
-                        <td class="px-4 py-3">
-                          <span class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm">
-                            <svg class="h-3.5 w-3.5 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
-                            <span x-text="section.instructor"></span>
-                          </span>
-                        </td>
-                        <td class="px-4 py-3 text-sm text-slate-700">
-                          <div class="font-semibold" x-text="`${section.enrolled}/${section.capacity}`"></div>
-                          <p class="text-xs text-slate-500" x-text="section.waitlist ? `${section.waitlist} waitlisted` : 'No waitlist'"></p>
-                        </td>
-                        <td class="px-4 py-3 text-sm text-slate-700" x-text="section.room"></td>
-                      </tr>
-                    </template>
-                  </tbody>
-                </table>
+            <div class="mt-6">
+              <div x-cloak x-show="loadError" x-transition class="rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+                <p class="font-medium">Unable to load sections.</p>
+                <p class="mt-1 text-rose-600" x-text="loadError"></p>
               </div>
-            </div>
 
-            <template x-if="filteredSections.length === 0">
-              <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
-                  <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
-                </span>
-                <div>
-                  <h3 class="text-lg font-semibold text-slate-900">No sections scheduled</h3>
-                  <p class="mt-1 text-sm text-slate-500">Adjust search filters or create a new section to fill the gap.</p>
+              <template x-if="loading">
+                <div class="overflow-hidden rounded-2xl border border-slate-200">
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                      <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                        <tr>
+                          <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Course</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Instructor</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Capacity</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Room</th>
+                          <th scope="col" class="px-4 py-3 font-semibold text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-100 bg-white">
+                        <template x-for="i in 5" :key="i">
+                          <tr>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-24 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-40 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-20 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-32 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-16 rounded"></span></td>
+                            <td class="px-4 py-3"><span class="skeleton-line h-4 w-20 rounded"></span></td>
+                            <td class="px-4 py-3 text-right"><span class="skeleton-line h-4 w-24 rounded ml-auto block"></span></td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
-            </template>
+              </template>
+
+              <template x-if="!loading && !loadError && filteredSections.length">
+                <div class="overflow-hidden rounded-2xl border border-slate-200">
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-left text-sm table-sticky-header">
+                      <thead class="bg-slate-50 text-xs uppercase tracking-wider text-slate-500">
+                        <tr>
+                          <th scope="col" class="px-4 py-3 font-semibold">Section</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Course</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Semester</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Instructor</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Capacity</th>
+                          <th scope="col" class="px-4 py-3 font-semibold">Room</th>
+                          <th scope="col" class="px-4 py-3 font-semibold text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-100 bg-white">
+                        <template x-for="section in filteredSections" :key="section._id">
+                          <tr class="hover:bg-slate-50">
+                            <td class="px-4 py-3">
+                              <div class="font-mono text-xs font-medium text-slate-600" x-text="section._id"></div>
+                              <p class="text-xs text-slate-500" x-show="section.section_no" x-text="`Sec ${section.section_no}`"></p>
+                            </td>
+                            <td class="px-4 py-3">
+                              <div class="font-medium text-slate-900" x-text="section.course_title || courseMap[section.course_id] || section.course_id"></div>
+                              <p class="text-xs text-slate-500" x-text="section.course_id"></p>
+                            </td>
+                            <td class="px-4 py-3">
+                              <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-700">
+                                <span class="h-2 w-2 rounded-full bg-slate-400"></span>
+                                <span x-text="section.semester"></span>
+                              </span>
+                            </td>
+                            <td class="px-4 py-3">
+                              <span class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 shadow-sm">
+                                <svg class="h-3.5 w-3.5 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+                                <span x-text="section.instructor_id || '—'"></span>
+                              </span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-slate-700">
+                              <div class="font-semibold" x-text="section.capacity != null ? section.capacity : '—'"></div>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-slate-700">
+                              <div x-text="section.room || '—'"></div>
+                              <p class="text-xs text-slate-500" x-show="section.schedule && section.schedule.length" x-text="section.schedule.join(', ')"></p>
+                            </td>
+                            <td class="px-4 py-3 text-right">
+                              <div class="inline-flex items-center gap-2">
+                                <button type="button" @click="openEdit(section)" class="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300 hover:text-slate-900">
+                                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4.5 19.5 3.75-.938a2 2 0 0 0 .938-.52l9.02-9.02a1.5 1.5 0 0 0-2.121-2.122l-9.02 9.02a2 2 0 0 0-.52.938L4.5 19.5Z" /><path d="M14.25 6.75 17.25 9.75" /></svg>
+                                  Edit
+                                </button>
+                                <button type="button" @click="deleteSection(section._id)" :disabled="deletingId === section._id" class="inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50">
+                                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6.75 7.5h10.5" stroke-linecap="round" /><path d="M9 7.5V6a1.5 1.5 0 0 1 1.5-1.5h3A1.5 1.5 0 0 1 15 6v1.5" /><path d="M8.25 7.5V18a1.5 1.5 0 0 0 1.5 1.5h4.5A1.5 1.5 0 0 0 15.75 18V7.5" /></svg>
+                                  <span x-text="deletingId === section._id ? 'Removing…' : 'Delete'"></span>
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </template>
+
+              <template x-if="!loading && !loadError && filteredSections.length === 0">
+                <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 py-12 text-center">
+                  <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
+                    <svg class="h-6 w-6 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M7.5 4.5h9L21 12l-4.5 7.5h-9L3 12 7.5 4.5Z" /><path d="M12 9v6" stroke-linecap="round" /><path d="M9 12h6" stroke-linecap="round" /></svg>
+                  </span>
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-900">No sections scheduled</h3>
+                    <p class="mt-1 text-sm text-slate-500">Adjust filters or create a new section to fill the gap.</p>
+                  </div>
+                </div>
+              </template>
+            </div>
           </section>
         </div>
       </main>
     </div>
   </div>
 
-  <script>
-    const sectionSeed = [
-      { id: 'SEC-101', course_id: 'CIS-210', course_title: 'Data Structures', semester: '2025 Spring', instructor: 'Dr. Maya Li', capacity: 32, enrolled: 29, waitlist: 2, room: 'ENG 210' },
-      { id: 'SEC-102', course_id: 'CIS-330', course_title: 'Operating Systems', semester: '2025 Spring', instructor: 'Prof. Victor Tan', capacity: 28, enrolled: 27, waitlist: 0, room: 'CS 301' },
-      { id: 'SEC-103', course_id: 'MTH-240', course_title: 'Linear Algebra', semester: '2025 Spring', instructor: 'Dr. Ana Gomez', capacity: 30, enrolled: 30, waitlist: 4, room: 'SCI 112' },
-      { id: 'SEC-104', course_id: 'BIO-120', course_title: 'Genetics', semester: '2025 Summer', instructor: 'Dr. Leah Bennett', capacity: 24, enrolled: 20, waitlist: 0, room: 'BIO 220' },
-      { id: 'SEC-105', course_id: 'ECON-201', course_title: 'Microeconomics', semester: '2025 Fall', instructor: 'Dr. Omar Haddad', capacity: 40, enrolled: 36, waitlist: 3, room: 'BUS 105' },
-      { id: 'SEC-106', course_id: 'PHYS-330', course_title: 'Quantum Mechanics', semester: '2025 Fall', instructor: 'Prof. Helena Ruiz', capacity: 22, enrolled: 18, waitlist: 0, room: 'PHY 410' },
-      { id: 'SEC-107', course_id: 'BUS-210', course_title: 'Managerial Finance', semester: '2025 Fall', instructor: 'Dr. Daniel Ortiz', capacity: 35, enrolled: 31, waitlist: 1, room: 'BUS 204' }
-    ];
+  <div x-cloak x-show="toast.visible" x-transition class="fixed top-4 right-4 z-50 w-full max-w-sm rounded-xl border px-4 py-3 shadow-lg" :class="toast.variant === 'success' ? 'border-emerald-200 bg-emerald-50/90 text-emerald-800' : 'border-rose-200 bg-rose-50/90 text-rose-700'" role="status" aria-live="polite">
+    <div class="flex items-start gap-3">
+      <span class="mt-0.5 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full" :class="toast.variant === 'success' ? 'bg-emerald-600 text-white' : 'bg-rose-600 text-white'">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <template x-if="toast.variant === 'success'"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></template>
+          <template x-if="toast.variant !== 'success'"><path d="M15 9 9 15m0-6 6 6" stroke-linecap="round" stroke-linejoin="round" /></template>
+        </svg>
+      </span>
+      <div>
+        <p class="text-sm font-semibold" x-text="toast.message"></p>
+        <p class="text-xs text-slate-500" x-text="toast.detail"></p>
+      </div>
+      <button type="button" class="ml-auto text-xs font-medium text-slate-500 hover:text-slate-700" @click="toast.visible = false">Dismiss</button>
+    </div>
+  </div>
 
+  <div x-cloak x-show="modalOpen" class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6" role="dialog" aria-modal="true">
+    <div class="absolute inset-0 bg-slate-900/40" @click="closeModal()"></div>
+    <div class="relative w-full max-w-2xl rounded-2xl border border-slate-200 bg-white p-6 shadow-xl" x-trap.noscroll="modalOpen" x-transition>
+      <header class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-xs uppercase tracking-widest text-slate-400" x-text="isEditing ? 'Update section' : 'Create section'"></p>
+          <h2 class="text-2xl font-semibold text-slate-900" x-text="isEditing ? 'Edit section' : 'Add new section'"></h2>
+        </div>
+        <button type="button" class="rounded-lg border border-transparent p-2 text-slate-400 hover:text-slate-600" @click="closeModal()" aria-label="Close dialog">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 9l6 6m0-6-6 6" stroke-linecap="round" /></svg>
+        </button>
+      </header>
+
+      <form class="mt-6 space-y-5" @submit.prevent="saveSection()">
+        <div class="grid gap-5 sm:grid-cols-2">
+          <div>
+            <label for="section-id" class="text-sm font-medium text-slate-700">Section ID</label>
+            <input id="section-id" type="text" x-model="form._id" :disabled="isEditing" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:bg-slate-50" :class="errors._id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. SEC-CS101-2025A-01" required />
+            <p class="mt-1 text-xs text-slate-500">Use the registrar-friendly identifier.</p>
+            <p x-show="errors._id" x-text="errors._id" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="section-course" class="text-sm font-medium text-slate-700">Course</label>
+            <select id="section-course" x-model="form.course_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.course_id ? 'border-rose-300' : 'border-slate-200'" required>
+              <option value="" disabled>Select course</option>
+              <template x-for="course in courseOptions" :key="course._id">
+                <option :value="course._id" x-text="`${course.title} (${course._id})`"></option>
+              </template>
+            </select>
+            <p class="mt-1 text-xs text-slate-500" x-show="!courseOptions.length">No courses available yet — create a course first.</p>
+            <p x-show="errors.course_id" x-text="errors.course_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+        </div>
+
+        <div class="grid gap-5 sm:grid-cols-3">
+          <div>
+            <label for="section-semester" class="text-sm font-medium text-slate-700">Semester</label>
+            <input id="section-semester" type="text" x-model="form.semester" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.semester ? 'border-rose-300' : 'border-slate-200'" placeholder="2025A" required />
+            <p x-show="errors.semester" x-text="errors.semester" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="section-number" class="text-sm font-medium text-slate-700">Section number</label>
+            <input id="section-number" type="text" x-model="form.section_no" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.section_no ? 'border-rose-300' : 'border-slate-200'" placeholder="01" required />
+            <p x-show="errors.section_no" x-text="errors.section_no" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="section-capacity" class="text-sm font-medium text-slate-700">Capacity</label>
+            <input id="section-capacity" type="number" min="0" step="1" x-model.number="form.capacity" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.capacity ? 'border-rose-300' : 'border-slate-200'" placeholder="30" required />
+            <p x-show="errors.capacity" x-text="errors.capacity" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+        </div>
+
+        <div class="grid gap-5 sm:grid-cols-2">
+          <div>
+            <label for="section-instructor" class="text-sm font-medium text-slate-700">Instructor ID</label>
+            <input id="section-instructor" type="text" x-model="form.instructor_id" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.instructor_id ? 'border-rose-300' : 'border-slate-200'" placeholder="e.g. I-1001" required />
+            <p x-show="errors.instructor_id" x-text="errors.instructor_id" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+          <div>
+            <label for="section-room" class="text-sm font-medium text-slate-700">Room</label>
+            <input id="section-room" type="text" x-model="form.room" class="mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" :class="errors.room ? 'border-rose-300' : 'border-slate-200'" placeholder="ENG-201" required />
+            <p x-show="errors.room" x-text="errors.room" class="mt-1 text-xs font-medium text-rose-600"></p>
+          </div>
+        </div>
+
+        <div>
+          <label for="section-schedule" class="text-sm font-medium text-slate-700">Meeting pattern</label>
+          <textarea id="section-schedule" rows="3" x-model="form.schedule_text" class="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="Mon 09:00-10:15&#10;Wed 09:00-10:15"></textarea>
+          <p class="mt-1 text-xs text-slate-500">Enter one meeting per line. Leave blank if the schedule is not finalized.</p>
+        </div>
+
+        <div class="flex items-center justify-end gap-3 pt-2">
+          <button type="button" class="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300 disabled:opacity-50" @click="closeModal()" :disabled="saving">Cancel</button>
+          <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth disabled:opacity-50" :disabled="saving">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M5.25 12.75 9 16.5l9-9" stroke-linecap="round" stroke-linejoin="round" /></svg>
+            <span x-text="saving ? 'Saving…' : 'Save section'"></span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
     document.addEventListener('alpine:init', () => {
       Alpine.data('sectionsPage', () => ({
-        sections: sectionSeed.map((section) => ({ ...section })),
-        search: '',
+        sections: [],
+        courses: [],
+        loading: true,
+        loadError: '',
+        courseFilter: '',
         selectedSemester: '',
+        modalOpen: false,
+        isEditing: false,
+        saving: false,
+        deletingId: '',
+        toastTimeout: null,
+        toast: { visible: false, message: '', detail: '', variant: 'success' },
+        form: {
+          _id: '',
+          course_id: '',
+          semester: '',
+          section_no: '',
+          instructor_id: '',
+          capacity: '',
+          room: '',
+          schedule_text: ''
+        },
+        errors: {},
+        get courseOptions() {
+          return [...this.courses].sort((a, b) => a.title.localeCompare(b.title));
+        },
+        get courseMap() {
+          return this.courses.reduce((acc, course) => {
+            acc[course._id] = course.title;
+            return acc;
+          }, {});
+        },
         get semesters() {
-          return [...new Set(this.sections.map((section) => section.semester))];
+          return [...new Set(this.sections.map((section) => section.semester).filter(Boolean))].sort();
         },
         get filteredSections() {
-          const term = this.search.trim().toLowerCase();
+          const term = this.courseFilter.trim().toLowerCase();
           return this.sections.filter((section) => {
             const matchesSemester = this.selectedSemester ? section.semester === this.selectedSemester : true;
-            const matchesSearch = term
-              ? [section.course_title, section.course_id, section.instructor, section.room].some((value) =>
-                  (value || '').toLowerCase().includes(term)
-                )
+            const matchesCourse = term
+              ? [section.course_title, section.course_id]
+                  .some((value) => String(value || '').toLowerCase().includes(term))
               : true;
-            return matchesSemester && matchesSearch;
+            return matchesSemester && matchesCourse;
           });
+        },
+        init() {
+          this.loadData();
+        },
+        async loadData() {
+          this.loading = true;
+          this.loadError = '';
+          try {
+            const [sections, courses] = await Promise.all([
+              this.requestSections(),
+              this.requestCourses().catch((error) => {
+                console.error('Failed to load courses', error);
+                this.showToast('Unable to load course catalog.', 'error', 'Course dropdown may be incomplete.');
+                return [];
+              })
+            ]);
+            this.sections = sections;
+            this.courses = courses;
+          } catch (error) {
+            console.error('Failed to load sections', error);
+            this.sections = [];
+            this.courses = [];
+            this.loadError = error instanceof Error ? error.message : 'Please refresh and try again.';
+            this.showToast('Unable to load sections.', 'error', 'Check your network connection.');
+          } finally {
+            this.loading = false;
+          }
+        },
+        async requestSections() {
+          const response = await fetch('/api/sections');
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !Array.isArray(payload)) {
+            const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          return payload.map((section) => ({
+            _id: section._id ?? '',
+            course_id: section.course_id ?? '',
+            course_title: section.course_title ?? '',
+            semester: section.semester ?? '',
+            section_no: section.section_no ?? '',
+            instructor_id: section.instructor_id ?? '',
+            capacity: section.capacity != null ? Number(section.capacity) : null,
+            room: section.room ?? '',
+            schedule: Array.isArray(section.schedule) ? section.schedule : []
+          }));
+        },
+        async requestCourses() {
+          const response = await fetch('/api/courses?limit=500');
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !Array.isArray(payload)) {
+            const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          return payload.map((course) => ({
+            _id: course._id ?? '',
+            title: course.title ?? course._id ?? ''
+          }));
+        },
+        async refreshSections() {
+          this.sections = await this.requestSections();
+        },
+        async refreshCoursesIfNeeded(courseId) {
+          if (!courseId) return;
+          const exists = this.courses.some((course) => course._id === courseId);
+          if (!exists) {
+            try {
+              this.courses = await this.requestCourses();
+            } catch (error) {
+              console.error('Failed to refresh courses', error);
+            }
+          }
+        },
+        openCreate() {
+          this.isEditing = false;
+          this.form = {
+            _id: '',
+            course_id: '',
+            semester: '',
+            section_no: '',
+            instructor_id: '',
+            capacity: '',
+            room: '',
+            schedule_text: ''
+          };
+          this.errors = {};
+          this.saving = false;
+          this.modalOpen = true;
+        },
+        openEdit(section) {
+          this.isEditing = true;
+          this.form = {
+            _id: section._id,
+            course_id: section.course_id,
+            semester: section.semester,
+            section_no: section.section_no,
+            instructor_id: section.instructor_id,
+            capacity: section.capacity != null ? Number(section.capacity) : '',
+            room: section.room || '',
+            schedule_text: Array.isArray(section.schedule) ? section.schedule.join('\n') : ''
+          };
+          this.errors = {};
+          this.saving = false;
+          this.modalOpen = true;
+        },
+        closeModal() {
+          if (this.saving) return;
+          this.modalOpen = false;
+          this.form = {
+            _id: '',
+            course_id: '',
+            semester: '',
+            section_no: '',
+            instructor_id: '',
+            capacity: '',
+            room: '',
+            schedule_text: ''
+          };
+          this.errors = {};
+        },
+        validate() {
+          const nextErrors = {};
+          if (!this.form._id.trim()) nextErrors._id = 'Section ID is required.';
+          if (!this.form.course_id) nextErrors.course_id = 'Select a course.';
+          if (!this.form.semester.trim()) nextErrors.semester = 'Semester is required.';
+          if (!this.form.section_no.trim()) nextErrors.section_no = 'Section number is required.';
+          if (!this.form.instructor_id.trim()) nextErrors.instructor_id = 'Instructor ID is required.';
+          if (this.form.capacity === '' || Number.isNaN(Number(this.form.capacity)) || Number(this.form.capacity) < 0) {
+            nextErrors.capacity = 'Capacity must be zero or greater.';
+          }
+          if (!this.form.room.trim()) nextErrors.room = 'Room is required.';
+          this.errors = nextErrors;
+          return Object.keys(nextErrors).length === 0;
+        },
+        buildPayload() {
+          const scheduleEntries = this.form.schedule_text
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length);
+          return {
+            _id: this.form._id.trim(),
+            course_id: this.form.course_id,
+            semester: this.form.semester.trim().toUpperCase(),
+            section_no: this.form.section_no.trim(),
+            instructor_id: this.form.instructor_id.trim(),
+            capacity: Number(this.form.capacity),
+            room: this.form.room.trim(),
+            schedule: scheduleEntries
+          };
+        },
+        async saveSection() {
+          if (!this.validate()) {
+            this.showToast('Please review the highlighted fields.', 'error', 'Missing required information.');
+            return;
+          }
+
+          this.saving = true;
+          const payload = this.buildPayload();
+          const method = this.isEditing ? 'PUT' : 'POST';
+          const url = this.isEditing
+            ? `/api/sections/${encodeURIComponent(this.form._id)}`
+            : '/api/sections';
+
+          if (this.isEditing) {
+            delete payload._id;
+          }
+
+          try {
+            const response = await fetch(url, {
+              method,
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload)
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result) {
+              const details = (result && result.details) || {};
+              this.errors = details;
+              const detailMessage =
+                details.course_id ||
+                details.section_no ||
+                details.semester ||
+                Object.values(details)[0] || '';
+              this.showToast((result && result.error) || 'Unable to save section.', 'error', detailMessage);
+              return;
+            }
+
+            await this.refreshSections();
+            await this.refreshCoursesIfNeeded(this.form.course_id);
+            this.closeModal();
+            this.showToast(
+              this.isEditing ? 'Section updated successfully.' : 'Section created successfully.',
+              'success',
+              this.isEditing ? 'Schedule refreshed.' : 'Section is ready for enrollment.'
+            );
+          } catch (error) {
+            console.error('Failed to save section', error);
+            this.showToast('Unable to save section.', 'error', 'Check your network connection.');
+          } finally {
+            this.saving = false;
+          }
+        },
+        async deleteSection(id) {
+          if (!window.confirm('Remove this section from the schedule?')) {
+            return;
+          }
+
+          this.deletingId = id;
+
+          try {
+            const response = await fetch(`/api/sections/${encodeURIComponent(id)}`, {
+              method: 'DELETE'
+            });
+            const result = await response.json().catch(() => null);
+
+            if (!response.ok || !result || !result.deleted) {
+              this.showToast(
+                (result && result.error) || 'Unable to delete section.',
+                'error',
+                'Please try again in a moment.'
+              );
+              return;
+            }
+
+            this.sections = this.sections.filter((section) => section._id !== id);
+            const detail = result.enrollments
+              ? `${result.enrollments} enrollment(s) may require reassignment.`
+              : 'Section removed from the schedule.';
+            this.showToast('Section removed.', 'success', detail);
+          } catch (error) {
+            console.error('Failed to delete section', error);
+            this.showToast('Unable to delete section.', 'error', 'Check your network connection.');
+          } finally {
+            this.deletingId = '';
+          }
+        },
+        showToast(message, variant = 'success', detail = '') {
+          if (this.toastTimeout) {
+            clearTimeout(this.toastTimeout);
+          }
+          this.toast = { visible: true, message, variant, detail };
+          this.toastTimeout = setTimeout(() => {
+            this.toast.visible = false;
+          }, 3200);
         }
       }));
     });

--- a/scripts/seed.json
+++ b/scripts/seed.json
@@ -72,5 +72,123 @@
       "pronouns": "he/him",
       "phone": "+1 (555) 010-1008"
     }
+  ],
+  "courses": [
+    {
+      "_id": "CS101",
+      "title": "Introduction to Computer Science",
+      "dept_id": "CS",
+      "credits": 3,
+      "description": "Foundational problem-solving, algorithms, and Python programming.",
+      "prereq_ids": []
+    },
+    {
+      "_id": "CS202",
+      "title": "Data Structures",
+      "dept_id": "CS",
+      "credits": 4,
+      "description": "Implementation of trees, graphs, and advanced data organization techniques.",
+      "prereq_ids": ["CS101"]
+    },
+    {
+      "_id": "MATH220",
+      "title": "Linear Algebra",
+      "dept_id": "MATH",
+      "credits": 3,
+      "description": "Vector spaces, eigenvalues, and applications for scientific computing.",
+      "prereq_ids": []
+    },
+    {
+      "_id": "ECON210",
+      "title": "Microeconomics",
+      "dept_id": "ECON",
+      "credits": 3,
+      "description": "Consumer theory, firm behavior, and market efficiency.",
+      "prereq_ids": []
+    }
+  ],
+  "class_sections": [
+    {
+      "_id": "SEC-CS101-2025A-01",
+      "course_id": "CS101",
+      "semester": "2025A",
+      "section_no": "01",
+      "instructor_id": "I-1001",
+      "capacity": 32,
+      "room": "ENG-201",
+      "schedule": ["Mon 09:00-10:15", "Wed 09:00-10:15"]
+    },
+    {
+      "_id": "SEC-CS202-2025A-01",
+      "course_id": "CS202",
+      "semester": "2025A",
+      "section_no": "01",
+      "instructor_id": "I-1002",
+      "capacity": 28,
+      "room": "ENG-305",
+      "schedule": ["Tue 11:00-12:15", "Thu 11:00-12:15"]
+    },
+    {
+      "_id": "SEC-MATH220-2025A-01",
+      "course_id": "MATH220",
+      "semester": "2025A",
+      "section_no": "01",
+      "instructor_id": "I-2001",
+      "capacity": 40,
+      "room": "SCI-110",
+      "schedule": ["Mon 14:00-15:15", "Wed 14:00-15:15"]
+    },
+    {
+      "_id": "SEC-ECON210-2025A-01",
+      "course_id": "ECON210",
+      "semester": "2025A",
+      "section_no": "01",
+      "instructor_id": "I-3001",
+      "capacity": 35,
+      "room": "BUS-120",
+      "schedule": ["Tue 09:30-10:45", "Thu 09:30-10:45"]
+    }
+  ],
+  "enrollments": [
+    {
+      "_id": "S-1001:SEC-CS101-2025A-01",
+      "student_id": "S-1001",
+      "section_id": "SEC-CS101-2025A-01",
+      "semester": "2025A",
+      "midterm": 88,
+      "final": 92,
+      "bonus": 2,
+      "letter": "A-"
+    },
+    {
+      "_id": "S-1002:SEC-MATH220-2025A-01",
+      "student_id": "S-1002",
+      "section_id": "SEC-MATH220-2025A-01",
+      "semester": "2025A",
+      "midterm": 91,
+      "final": 87,
+      "bonus": 1,
+      "letter": "A-"
+    },
+    {
+      "_id": "S-1003:SEC-ECON210-2025A-01",
+      "student_id": "S-1003",
+      "section_id": "SEC-ECON210-2025A-01",
+      "semester": "2025A",
+      "midterm": 84,
+      "final": 89,
+      "bonus": 0,
+      "letter": "B+"
+    },
+    {
+      "_id": "S-1004:SEC-CS202-2025A-01",
+      "student_id": "S-1004",
+      "section_id": "SEC-CS202-2025A-01",
+      "semester": "2025A",
+      "midterm": 79,
+      "final": 85,
+      "bonus": 3,
+      "letter": "B"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add Mongo-backed CRUD endpoints for courses, sections, and enrollments plus /api/stats aggregations
- create indexes and seed data for the new collections and refresh API docs
- connect dashboard, courses, sections, and enrollments pages to live APIs with loading, filtering, and toast UX

## Testing
- python -m compileall backend
