### PR TITLE
feat: add reports endpoints and UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,11 +19,14 @@ from src.db import (
     serialize_student,
     get_db,
 )
+from src.routes import reports_bp
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_FOLDER = BASE_DIR.parent / "frontend"
 
 app = Flask(__name__, static_folder=str(STATIC_FOLDER), static_url_path="/")
+
+app.register_blueprint(reports_bp)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -184,8 +184,18 @@ def _ensure_enrollments_indexes(collection: Collection) -> None:
             background=True,
         ),
         IndexModel(
+            [("section_id", ASCENDING), ("semester", ASCENDING)],
+            name="section_semester",
+            background=True,
+        ),
+        IndexModel(
             [("student_id", ASCENDING), ("semester", ASCENDING)],
             name="student_semester",
+            background=True,
+        ),
+        IndexModel(
+            [("semester", ASCENDING)],
+            name="semester_idx",
             background=True,
         ),
         IndexModel(

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Application route blueprints."""
+
+from .reports import reports_bp
+
+__all__ = ["reports_bp"]

--- a/backend/src/routes/reports.py
+++ b/backend/src/routes/reports.py
@@ -1,0 +1,399 @@
+"""Reports and analytics endpoints."""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from typing import Any, Dict, Iterable, List, Tuple
+
+from flask import Blueprint, Response, jsonify, request
+from pymongo.errors import PyMongoError
+
+from ..config import ConfigError
+from ..db import (
+    get_courses_collection,
+    get_enrollments_collection,
+    get_sections_collection,
+    get_students_collection,
+)
+
+reports_bp = Blueprint("reports", __name__, url_prefix="/api/reports")
+
+logger = logging.getLogger(__name__)
+
+GRADE_POINTS: Dict[str, float] = {
+    "A+": 4.0,
+    "A": 4.0,
+    "A-": 3.7,
+    "B+": 3.3,
+    "B": 3.0,
+    "B-": 2.7,
+    "C+": 2.3,
+    "C": 2.0,
+    "C-": 1.7,
+    "D+": 1.3,
+    "D": 1.0,
+    "D-": 0.7,
+    "F": 0.0,
+}
+
+GRADE_ORDER: Tuple[str, ...] = (
+    "A+",
+    "A",
+    "A-",
+    "B+",
+    "B",
+    "B-",
+    "C+",
+    "C",
+    "C-",
+    "D+",
+    "D",
+    "D-",
+    "F",
+)
+
+GRADE_ORDER_INDEX = {grade: index for index, grade in enumerate(GRADE_ORDER)}
+
+
+def _json_error(message: str, status: int, details: Dict[str, Any] | None = None):
+    payload: Dict[str, Any] = {"error": message}
+    if details:
+        payload["details"] = details
+    return jsonify(payload), status
+
+
+def _clean_string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _normalize_semester(value: str | None) -> str | None:
+    cleaned = _clean_string(value)
+    return cleaned.upper() if cleaned else None
+
+
+def _format_numeric(value: float | int | None) -> float | int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(value)
+    number = float(value)
+    if abs(number - round(number)) < 1e-9:
+        return int(round(number))
+    return round(number, 2)
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@reports_bp.get("/gpa/<student_id>")
+def student_gpa(student_id: str):
+    student_id_clean = _clean_string(student_id)
+    if not student_id_clean:
+        return _json_error("Student ID is required.", 400)
+
+    semester = _normalize_semester(request.args.get("semester"))
+
+    try:
+        students_collection = get_students_collection()
+        student_exists = students_collection.find_one({"_id": student_id_clean}, {"_id": 1})
+        if not student_exists:
+            return _json_error("Student not found.", 404)
+
+        enrollments_collection = get_enrollments_collection()
+        # Ensure supporting indexes exist for lookups
+        get_sections_collection()
+        get_courses_collection()
+
+        match_stage: Dict[str, Any] = {"student_id": student_id_clean}
+        if semester:
+            match_stage["semester"] = semester
+
+        pipeline: List[Dict[str, Any]] = [
+            {"$match": match_stage},
+            {
+                "$lookup": {
+                    "from": "class_sections",
+                    "localField": "section_id",
+                    "foreignField": "_id",
+                    "as": "section",
+                }
+            },
+            {"$unwind": {"path": "$section", "preserveNullAndEmptyArrays": True}},
+            {
+                "$lookup": {
+                    "from": "courses",
+                    "localField": "section.course_id",
+                    "foreignField": "_id",
+                    "as": "course",
+                }
+            },
+            {"$unwind": {"path": "$course", "preserveNullAndEmptyArrays": True}},
+            {
+                "$project": {
+                    "_id": 0,
+                    "student_id": 1,
+                    "section_id": 1,
+                    "semester": 1,
+                    "letter": {"$ifNull": ["$letter", None]},
+                    "course_id": "$section.course_id",
+                    "credits": {"$ifNull": ["$course.credits", 0]},
+                }
+            },
+        ]
+
+        results: List[Dict[str, Any]] = list(enrollments_collection.aggregate(pipeline))
+
+        details: List[Dict[str, Any]] = []
+        quality_points = 0.0
+        total_credits = 0.0
+
+        for entry in results:
+            course_id = entry.get("course_id") or ""
+            section_id = entry.get("section_id") or ""
+            letter_raw = entry.get("letter")
+            letter = _clean_string(letter_raw).upper() if letter_raw is not None else None
+            credits_value = _safe_float(entry.get("credits"))
+
+            if credits_value < 0:
+                credits_value = 0.0
+
+            if letter and letter not in GRADE_POINTS:
+                letter = None
+
+            detail_record = {
+                "course_id": course_id,
+                "section_id": section_id,
+                "credits": _format_numeric(credits_value) or 0,
+                "letter": letter,
+            }
+            details.append(detail_record)
+
+            if letter and credits_value > 0:
+                total_credits += credits_value
+                quality_points += GRADE_POINTS[letter] * credits_value
+
+        details.sort(key=lambda item: (item.get("course_id") or "", item.get("section_id") or ""))
+
+        gpa_value: float | None
+        if total_credits > 0:
+            gpa_value = round(quality_points / total_credits, 2)
+        else:
+            gpa_value = None
+
+        payload: Dict[str, Any] = {
+            "student_id": student_id_clean,
+            "total_credits": _format_numeric(total_credits) or 0,
+            "gpa": gpa_value,
+            "details": details,
+        }
+        if semester:
+            payload["semester"] = semester
+
+        return jsonify(payload)
+    except ConfigError as exc:
+        logger.exception("Missing configuration for MongoDB")
+        return _json_error(str(exc), 500)
+    except PyMongoError:
+        logger.exception("Failed to generate GPA report due to MongoDB error")
+        return _json_error("Database unavailable. Please try again later.", 503)
+
+
+@reports_bp.get("/course-stats/<course_id>")
+def course_stats(course_id: str):
+    course_id_clean = _clean_string(course_id)
+    if not course_id_clean:
+        return _json_error("Course ID is required.", 400)
+
+    semester = _normalize_semester(request.args.get("semester"))
+
+    try:
+        courses_collection = get_courses_collection()
+        course_doc = courses_collection.find_one({"_id": course_id_clean}, {"_id": 1, "title": 1})
+        if not course_doc:
+            return _json_error("Course not found.", 404)
+
+        enrollments_collection = get_enrollments_collection()
+        get_sections_collection()
+
+        match_filter: Dict[str, Any] = {"section.course_id": course_id_clean}
+        if semester:
+            match_filter["semester"] = semester
+            match_filter["section.semester"] = semester
+
+        pipeline: List[Dict[str, Any]] = [
+            {
+                "$lookup": {
+                    "from": "class_sections",
+                    "localField": "section_id",
+                    "foreignField": "_id",
+                    "as": "section",
+                }
+            },
+            {"$unwind": {"path": "$section", "preserveNullAndEmptyArrays": False}},
+            {"$match": match_filter},
+            {
+                "$facet": {
+                    "summary": [
+                        {
+                            "$group": {
+                                "_id": None,
+                                "count": {"$sum": 1},
+                                "avg_midterm": {"$avg": "$midterm"},
+                                "avg_final": {"$avg": "$final"},
+                            }
+                        }
+                    ],
+                    "distribution": [
+                        {
+                            "$group": {
+                                "_id": {"$ifNull": ["$letter", ""]},
+                                "count": {"$sum": 1},
+                            }
+                        },
+                        {"$project": {"_id": 0, "letter": "$_id", "count": 1}},
+                    ],
+                }
+            },
+        ]
+
+        aggregated = list(enrollments_collection.aggregate(pipeline))
+        summary_doc = (aggregated[0]["summary"][0] if aggregated and aggregated[0]["summary"] else {})
+        distribution_docs: Iterable[Dict[str, Any]]
+        if aggregated:
+            distribution_docs = aggregated[0].get("distribution", [])
+        else:
+            distribution_docs = []
+
+        count = int(summary_doc.get("count", 0) or 0)
+        avg_midterm = summary_doc.get("avg_midterm")
+        avg_final = summary_doc.get("avg_final")
+
+        distribution: List[Dict[str, Any]] = []
+        for item in distribution_docs:
+            letter_raw = item.get("letter")
+            letter_clean = _clean_string(letter_raw).upper() if letter_raw is not None else ""
+            letter_display = letter_clean if letter_clean else "N/A"
+            distribution.append(
+                {
+                    "letter": letter_display,
+                    "count": int(item.get("count", 0) or 0),
+                }
+            )
+
+        distribution.sort(
+            key=lambda entry: GRADE_ORDER_INDEX.get(entry["letter"], len(GRADE_ORDER_INDEX))
+            if entry["letter"] != "N/A"
+            else len(GRADE_ORDER_INDEX) + 1
+        )
+
+        payload: Dict[str, Any] = {
+            "course_id": course_id_clean,
+            "count": count,
+            "avg_midterm": round(avg_midterm, 2) if isinstance(avg_midterm, (int, float)) else None,
+            "avg_final": round(avg_final, 2) if isinstance(avg_final, (int, float)) else None,
+            "distribution": distribution,
+            "course_title": course_doc.get("title"),
+        }
+        if semester:
+            payload["semester"] = semester
+
+        return jsonify(payload)
+    except ConfigError as exc:
+        logger.exception("Missing configuration for MongoDB")
+        return _json_error(str(exc), 500)
+    except PyMongoError:
+        logger.exception("Failed to generate course stats due to MongoDB error")
+        return _json_error("Database unavailable. Please try again later.", 503)
+
+
+@reports_bp.get("/enrollments.csv")
+def export_enrollments_csv():
+    semester = _normalize_semester(request.args.get("semester"))
+
+    try:
+        enrollments_collection = get_enrollments_collection()
+        get_sections_collection()
+
+        pipeline: List[Dict[str, Any]] = []
+        match_stage: Dict[str, Any] = {}
+        if semester:
+            match_stage["semester"] = semester
+        if match_stage:
+            pipeline.append({"$match": match_stage})
+
+        pipeline.extend(
+            [
+                {
+                    "$lookup": {
+                        "from": "class_sections",
+                        "localField": "section_id",
+                        "foreignField": "_id",
+                        "as": "section",
+                    }
+                },
+                {"$unwind": {"path": "$section", "preserveNullAndEmptyArrays": True}},
+                {
+                    "$project": {
+                        "_id": 0,
+                        "student_id": 1,
+                        "section_id": 1,
+                        "course_id": "$section.course_id",
+                        "semester": 1,
+                        "midterm": 1,
+                        "final": 1,
+                        "bonus": 1,
+                        "letter": {"$ifNull": ["$letter", ""]},
+                    }
+                },
+            ]
+        )
+
+        rows = list(enrollments_collection.aggregate(pipeline))
+
+        output = io.StringIO()
+        fieldnames = [
+            "student_id",
+            "section_id",
+            "course_id",
+            "semester",
+            "midterm",
+            "final",
+            "bonus",
+            "letter",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for row in rows:
+            writer.writerow({
+                "student_id": row.get("student_id", ""),
+                "section_id": row.get("section_id", ""),
+                "course_id": row.get("course_id", ""),
+                "semester": row.get("semester", ""),
+                "midterm": row.get("midterm", ""),
+                "final": row.get("final", ""),
+                "bonus": row.get("bonus", ""),
+                "letter": row.get("letter", ""),
+            })
+
+        csv_content = output.getvalue()
+        filename = "enrollments.csv" if not semester else f"enrollments_{semester}.csv"
+
+        response = Response(csv_content, mimetype="text/csv")
+        response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+        return response
+    except ConfigError as exc:
+        logger.exception("Missing configuration for MongoDB")
+        return _json_error(str(exc), 500)
+    except PyMongoError:
+        logger.exception("Failed to export enrollments due to MongoDB error")
+        return _json_error("Database unavailable. Please try again later.", 503)
+
+
+__all__ = ["reports_bp"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,12 @@
           </span>
           Enrollments
         </a>
+        <a href="/pages/reports.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
       </nav>
       <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
         <p>Academic year <span class="font-semibold text-slate-700">2025</span></p>
@@ -77,6 +83,7 @@
             <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
             <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
             <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="hover:text-slate-900">Reports</a>
           </nav>
         </div>
       </header>

--- a/frontend/pages/courses.html
+++ b/frontend/pages/courses.html
@@ -51,6 +51,12 @@
           </span>
           Enrollments
         </a>
+        <a href="/pages/reports.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
       </nav>
       <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
         <p>Catalog last synced <span class="font-semibold text-slate-700">3 mins ago</span></p>
@@ -76,6 +82,7 @@
             <a href="/pages/courses.html" class="text-slate-900">Courses</a>
             <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
             <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="hover:text-slate-900">Reports</a>
           </nav>
         </div>
       </header>

--- a/frontend/pages/enrollments.html
+++ b/frontend/pages/enrollments.html
@@ -51,6 +51,12 @@
           </span>
           Enrollments
         </a>
+        <a href="/pages/reports.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
       </nav>
       <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
         <p>Grade submission window <span class="font-semibold text-slate-700">May 8</span></p>
@@ -76,6 +82,7 @@
             <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
             <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
             <a href="/pages/enrollments.html" class="text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="hover:text-slate-900">Reports</a>
           </nav>
         </div>
       </header>

--- a/frontend/pages/reports.html
+++ b/frontend/pages/reports.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reports · Student Mgmt</title>
+  <link rel="stylesheet" href="../style.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://unpkg.com/@alpinejs/focus@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="min-h-screen bg-slate-100 text-slate-700" x-data="{ sidebarOpen: false }" x-on:keydown.escape.window="sidebarOpen = false">
+  <div class="flex min-h-screen">
+    <div x-cloak x-show="sidebarOpen" x-transition.opacity class="fixed inset-0 z-30 bg-slate-900/40 md:hidden" aria-hidden="true" @click="sidebarOpen = false"></div>
+    <aside x-cloak x-show="sidebarOpen" x-transition:enter="transition transform duration-200" x-transition:enter-start="-translate-x-full" x-transition:enter-end="translate-x-0" x-transition:leave="transition transform duration-200" x-transition:leave-start="translate-x-0" x-transition:leave-end="-translate-x-full" class="fixed inset-y-0 left-0 z-40 w-72 bg-white border-r border-slate-200 md:static md:translate-x-0 md:block">
+      <div class="flex items-center gap-3 px-6 h-16 border-b border-slate-100">
+        <img src="../assets/logo.svg" alt="Student Management logo" class="h-9 w-9" />
+        <div>
+          <p class="text-sm uppercase tracking-widest text-slate-400">Student Mgmt</p>
+          <p class="text-base font-semibold text-slate-800">Admin Console</p>
+        </div>
+      </div>
+      <nav class="px-4 py-6 space-y-1 text-sm font-medium">
+        <a href="/" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3 9.75 12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75Z" /><path d="M9 21v-6h6v6" stroke-linecap="round" /></svg>
+          </span>
+          Dashboard
+        </a>
+        <a href="/pages/students.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /><path d="M4.5 21a7.5 7.5 0 0 1 15 0" stroke-linecap="round" /></svg>
+          </span>
+          Students
+        </a>
+        <a href="/pages/courses.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 5.25h15" stroke-linecap="round" /><path d="M6 4.5h12A1.5 1.5 0 0 1 19.5 6v13.5a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V6A1.5 1.5 0 0 1 6 4.5Z" /><path d="M9 9h6m-6 4.5h6" stroke-linecap="round" /></svg>
+          </span>
+          Courses
+        </a>
+        <a href="/pages/sections.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 6.75h15" stroke-linecap="round" /><path d="M4.5 12h15" stroke-linecap="round" /><path d="M4.5 17.25h15" stroke-linecap="round" /></svg>
+          </span>
+          Sections
+        </a>
+        <a href="/pages/enrollments.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 4.5h15v15h-15z" /><path d="M8.25 8.25h7.5v7.5h-7.5z" /><path d="M8.25 4.5v3.75M15.75 4.5v3.75M4.5 12h3.75m7.5 0H19.5M8.25 16.5V19.5m7.5-3v3" stroke-linecap="round" /></svg>
+          </span>
+          Enrollments
+        </a>
+        <a href="/pages/reports.html" aria-current="page" class="flex items-center gap-3 rounded-xl px-3 py-2 bg-slate-900/5 text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
+      </nav>
+      <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
+        <p>Academic year <span class="font-semibold text-slate-700">2025</span></p>
+        <p class="mt-1">Performance insights refreshed hourly</p>
+      </div>
+    </aside>
+
+    <div class="flex-1 flex flex-col min-h-screen">
+      <header class="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div class="flex items-center justify-between px-4 sm:px-6 h-16">
+          <div class="flex items-center gap-3">
+            <button type="button" class="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 md:hidden" @click="sidebarOpen = true" aria-label="Open navigation menu">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" stroke-linecap="round" /></svg>
+            </button>
+            <div>
+              <p class="text-xs uppercase tracking-widest text-slate-400">Analytics</p>
+              <h1 class="text-lg font-semibold text-slate-900">Reports</h1>
+            </div>
+          </div>
+          <nav class="hidden md:flex items-center gap-6 text-sm font-medium text-slate-600">
+            <a href="/" class="hover:text-slate-900">Dashboard</a>
+            <a href="/pages/students.html" class="hover:text-slate-900">Students</a>
+            <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
+            <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
+            <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="text-slate-900">Reports</a>
+          </nav>
+        </div>
+      </header>
+
+      <main class="flex-1">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10" x-data="reportsPage()">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 class="text-3xl font-semibold text-slate-900">Performance intelligence</h2>
+              <p class="mt-2 text-slate-600">Surface cumulative GPAs, grade distributions, and enrollment exports backed by live MongoDB aggregations.</p>
+            </div>
+            <div class="flex flex-wrap gap-3 text-sm">
+              <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 font-medium text-slate-700 shadow-sm">
+                <svg class="h-4 w-4 text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 5.25v13.5" stroke-linecap="round" /><path d="M5.25 12h13.5" stroke-linecap="round" /></svg>
+                Updated from source grades
+              </span>
+              <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 font-semibold text-white shadow-smooth">
+                MongoDB Aggregations
+              </span>
+            </div>
+          </div>
+
+          <section class="mt-10 grid gap-6 lg:grid-cols-5">
+            <article class="lg:col-span-3 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <header class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-900">GPA lookup</h3>
+                  <p class="text-sm text-slate-500">Weighted GPA across enrolled course credits.</p>
+                </div>
+                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">4.0 scale</span>
+              </header>
+              <form class="mt-6 space-y-4" @submit.prevent="fetchGpa">
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <label class="flex flex-col text-sm font-medium text-slate-600">
+                    Student ID
+                    <input type="text" x-model="gpaForm.student_id" class="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. S-1001" required />
+                  </label>
+                  <label class="flex flex-col text-sm font-medium text-slate-600">
+                    Semester <span class="text-xs font-normal text-slate-400">(optional)</span>
+                    <input type="text" x-model="gpaForm.semester" class="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. 2025A" />
+                  </label>
+                </div>
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <p class="text-xs text-slate-500">Includes courses with assigned letter grades and credit hours.</p>
+                  <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth disabled:opacity-60" :disabled="gpaLoading">
+                    <svg x-show="!gpaLoading" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 6v12m6-6H6" stroke-linecap="round" /></svg>
+                    <svg x-show="gpaLoading" x-cloak class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9" stroke-opacity="0.25" /><path d="M21 12a9 9 0 0 0-9-9" stroke-linecap="round" /></svg>
+                    Lookup GPA
+                  </button>
+                </div>
+              </form>
+
+              <template x-if="gpaError">
+                <div x-cloak class="mt-4 rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+                  <p class="font-semibold">Unable to calculate GPA.</p>
+                  <p class="mt-1" x-text="gpaError"></p>
+                </div>
+              </template>
+
+              <template x-if="gpaResult">
+                <div x-cloak class="mt-6 space-y-6">
+                  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                      <p class="text-xs uppercase tracking-wide text-slate-400">Student</p>
+                      <p class="mt-2 text-sm font-semibold text-slate-800" x-text="gpaResult.student_id"></p>
+                    </div>
+                    <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                      <p class="text-xs uppercase tracking-wide text-slate-400">Semester</p>
+                      <p class="mt-2 text-sm font-semibold text-slate-800" x-text="gpaResult.semester || 'All terms'"></p>
+                    </div>
+                    <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                      <p class="text-xs uppercase tracking-wide text-slate-400">Total credits</p>
+                      <p class="mt-2 text-sm font-semibold text-slate-800" x-text="formatNumber(gpaResult.total_credits)"></p>
+                    </div>
+                    <div class="rounded-xl border border-slate-200 bg-emerald-50 px-4 py-3">
+                      <p class="text-xs uppercase tracking-wide text-emerald-600">GPA</p>
+                      <p class="mt-2 text-lg font-semibold text-emerald-700" x-text="formatDecimal(gpaResult.gpa)"></p>
+                    </div>
+                  </div>
+
+                  <div>
+                    <header class="flex items-center justify-between text-sm font-medium text-slate-600">
+                      <p>Course breakdown</p>
+                      <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500" x-text="`${gpaResult.details.length} record${gpaResult.details.length === 1 ? '' : 's'}`"></span>
+                    </header>
+                    <template x-if="gpaResult.details.length">
+                      <div class="mt-3 overflow-hidden rounded-xl border border-slate-200">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                          <thead class="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+                            <tr>
+                              <th scope="col" class="px-4 py-2">Course</th>
+                              <th scope="col" class="px-4 py-2">Section</th>
+                              <th scope="col" class="px-4 py-2 text-right">Credits</th>
+                              <th scope="col" class="px-4 py-2 text-right">Letter</th>
+                            </tr>
+                          </thead>
+                          <tbody class="divide-y divide-slate-100 bg-white text-slate-700">
+                            <template x-for="row in gpaResult.details" :key="`${row.course_id}-${row.section_id}`">
+                              <tr>
+                                <td class="px-4 py-2 font-medium" x-text="row.course_id || '—'"></td>
+                                <td class="px-4 py-2" x-text="row.section_id || '—'"></td>
+                                <td class="px-4 py-2 text-right" x-text="formatNumber(row.credits)"></td>
+                                <td class="px-4 py-2 text-right" x-text="row.letter || 'N/A'"></td>
+                              </tr>
+                            </template>
+                          </tbody>
+                        </table>
+                      </div>
+                    </template>
+                    <template x-if="!gpaResult.details.length">
+                      <p x-cloak class="mt-4 rounded-xl border border-dashed border-slate-200 bg-slate-50/70 px-4 py-6 text-center text-sm text-slate-500">No graded enrollments found for this selection.</p>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </article>
+
+            <article class="lg:col-span-2 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+              <header>
+                <h3 class="text-lg font-semibold text-slate-900">CSV export</h3>
+                <p class="text-sm text-slate-500">Download enrollments with section and grading details.</p>
+              </header>
+              <div class="mt-6 space-y-4">
+                <label class="flex flex-col text-sm font-medium text-slate-600">
+                  Semester filter <span class="text-xs font-normal text-slate-400">(optional)</span>
+                  <input type="text" x-model="csvSemester" class="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. 2025A" />
+                </label>
+                <p class="text-xs text-slate-500">When no semester is provided, all enrollments are exported.</p>
+                <a :href="csvDownloadUrl" :download="csvFilename" class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth">
+                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 3v12" stroke-linecap="round" /><path d="m7.5 10.5 4.5 4.5 4.5-4.5" stroke-linecap="round" stroke-linejoin="round" /><path d="M5.25 15.75v3a.75.75 0 0 0 .75.75h12a.75.75 0 0 0 .75-.75v-3" stroke-linecap="round" /></svg>
+                  Download enrollments.csv
+                </a>
+              </div>
+            </article>
+          </section>
+
+          <section class="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <header class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Course performance</h3>
+                <p class="text-sm text-slate-500">Aggregate grade trends for a specific course and term.</p>
+              </div>
+              <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Live averages</span>
+            </header>
+
+            <form class="mt-6 grid gap-4 md:grid-cols-4" @submit.prevent="fetchCourseStats">
+              <label class="flex flex-col text-sm font-medium text-slate-600 md:col-span-2">
+                Course ID
+                <input type="text" x-model="courseForm.course_id" class="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. CS101" required />
+              </label>
+              <label class="flex flex-col text-sm font-medium text-slate-600">
+                Semester <span class="text-xs font-normal text-slate-400">(optional)</span>
+                <input type="text" x-model="courseForm.semester" class="mt-1 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="e.g. 2025A" />
+              </label>
+              <div class="flex items-end">
+                <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-smooth disabled:opacity-60" :disabled="courseLoading">
+                  <svg x-show="!courseLoading" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m5.25 12 4.5 4.5L18.75 7.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
+                  <svg x-show="courseLoading" x-cloak class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9" stroke-opacity="0.25" /><path d="M21 12a9 9 0 0 0-9-9" stroke-linecap="round" /></svg>
+                  Generate stats
+                </button>
+              </div>
+            </form>
+
+            <template x-if="courseError">
+              <div x-cloak class="mt-4 rounded-xl border border-rose-200 bg-rose-50/80 p-4 text-sm text-rose-700" role="alert">
+                <p class="font-semibold">Unable to load course stats.</p>
+                <p class="mt-1" x-text="courseError"></p>
+              </div>
+            </template>
+
+            <template x-if="courseResult">
+              <div x-cloak class="mt-6 space-y-6">
+                <div class="grid gap-4 md:grid-cols-4">
+                  <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                    <p class="text-xs uppercase tracking-wide text-slate-400">Course</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-800" x-text="courseResult.course_id"></p>
+                    <p class="text-xs text-slate-500" x-text="courseResult.course_title || 'Untitled course'"></p>
+                  </div>
+                  <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                    <p class="text-xs uppercase tracking-wide text-slate-400">Semester</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-800" x-text="courseResult.semester || 'All terms'"></p>
+                  </div>
+                  <div class="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+                    <p class="text-xs uppercase tracking-wide text-slate-400">Enrollments</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-800" x-text="formatNumber(courseResult.count)"></p>
+                  </div>
+                  <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
+                    <p class="text-xs uppercase tracking-wide text-emerald-600">Average scores</p>
+                    <p class="mt-2 text-sm font-semibold text-emerald-700">Midterm <span x-text="formatDecimal(courseResult.avg_midterm)"></span> · Final <span x-text="formatDecimal(courseResult.avg_final)"></span></p>
+                  </div>
+                </div>
+
+                <div class="grid gap-6 lg:grid-cols-2">
+                  <div>
+                    <h4 class="text-sm font-semibold text-slate-700">Letter distribution</h4>
+                    <template x-if="courseResult.distribution.length">
+                      <div x-cloak class="mt-3 h-64">
+                        <canvas x-ref="distributionCanvas" aria-label="Bar chart showing grade distribution" role="img"></canvas>
+                      </div>
+                    </template>
+                    <template x-if="!courseResult.distribution.length">
+                      <p x-cloak class="mt-3 rounded-xl border border-dashed border-slate-200 bg-slate-50/70 px-4 py-6 text-center text-sm text-slate-500">No graded enrollments to chart yet.</p>
+                    </template>
+                  </div>
+                  <div>
+                    <h4 class="text-sm font-semibold text-slate-700">Counts by letter</h4>
+                    <ul class="mt-3 space-y-2 text-sm text-slate-600">
+                      <template x-for="entry in courseResult.distribution" :key="entry.letter">
+                        <li class="flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50/60 px-4 py-2">
+                          <span class="font-semibold text-slate-800" x-text="entry.letter"></span>
+                          <span x-text="formatNumber(entry.count)"></span>
+                        </li>
+                      </template>
+                      <template x-if="!courseResult.distribution.length">
+                        <li class="rounded-xl border border-dashed border-slate-200 bg-white px-4 py-3 text-center text-slate-500">Distribution pending grade submissions.</li>
+                      </template>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </section>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('alpine:init', () => {
+      Alpine.data('reportsPage', () => ({
+        gpaForm: { student_id: '', semester: '' },
+        gpaLoading: false,
+        gpaError: '',
+        gpaResult: null,
+        courseForm: { course_id: '', semester: '' },
+        courseLoading: false,
+        courseError: '',
+        courseResult: null,
+        distributionChart: null,
+        csvSemester: '',
+        async fetchGpa() {
+          const studentId = (this.gpaForm.student_id || '').trim();
+          const semester = (this.gpaForm.semester || '').trim().toUpperCase();
+          this.gpaForm.semester = semester;
+          if (!studentId) {
+            this.gpaError = 'Student ID is required.';
+            return;
+          }
+          this.gpaLoading = true;
+          this.gpaError = '';
+          this.gpaResult = null;
+          try {
+            const params = new URLSearchParams();
+            if (semester) params.set('semester', semester);
+            const response = await fetch(`/api/reports/gpa/${encodeURIComponent(studentId)}` + (params.toString() ? `?${params}` : ''));
+            const payload = await response.json().catch(() => null);
+            if (!response.ok || !payload) {
+              const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+              throw new Error(message);
+            }
+            this.gpaResult = {
+              student_id: payload.student_id,
+              semester: payload.semester || null,
+              total_credits: payload.total_credits ?? 0,
+              gpa: payload.gpa ?? null,
+              details: Array.isArray(payload.details) ? payload.details : [],
+            };
+          } catch (error) {
+            console.error('Failed to load GPA report', error);
+            this.gpaError = error instanceof Error ? error.message : 'Please try again with a different student ID.';
+          } finally {
+            this.gpaLoading = false;
+          }
+        },
+        async fetchCourseStats() {
+          const courseId = (this.courseForm.course_id || '').trim();
+          const semester = (this.courseForm.semester || '').trim().toUpperCase();
+          this.courseForm.semester = semester;
+          if (!courseId) {
+            this.courseError = 'Course ID is required.';
+            return;
+          }
+          this.courseLoading = true;
+          this.courseError = '';
+          this.courseResult = null;
+          this.destroyDistributionChart();
+          try {
+            const params = new URLSearchParams();
+            if (semester) params.set('semester', semester);
+            const response = await fetch(`/api/reports/course-stats/${encodeURIComponent(courseId)}` + (params.toString() ? `?${params}` : ''));
+            const payload = await response.json().catch(() => null);
+            if (!response.ok || !payload) {
+              const message = (payload && payload.error) || `Request failed with status ${response.status}`;
+              throw new Error(message);
+            }
+            this.courseResult = {
+              course_id: payload.course_id,
+              course_title: payload.course_title,
+              semester: payload.semester || null,
+              count: payload.count ?? 0,
+              avg_midterm: payload.avg_midterm ?? null,
+              avg_final: payload.avg_final ?? null,
+              distribution: Array.isArray(payload.distribution) ? payload.distribution : [],
+            };
+            this.$nextTick(() => {
+              this.renderDistributionChart();
+            });
+          } catch (error) {
+            console.error('Failed to load course stats', error);
+            this.courseError = error instanceof Error ? error.message : 'Please verify the course ID and try again.';
+          } finally {
+            this.courseLoading = false;
+          }
+        },
+        destroyDistributionChart() {
+          if (this.distributionChart) {
+            this.distributionChart.destroy();
+            this.distributionChart = null;
+          }
+        },
+        renderDistributionChart() {
+          if (!this.courseResult || !this.$refs.distributionCanvas) {
+            this.destroyDistributionChart();
+            return;
+          }
+          const labels = this.courseResult.distribution.map((entry) => entry.letter);
+          const data = this.courseResult.distribution.map((entry) => Number(entry.count) || 0);
+          if (!labels.length) {
+            this.destroyDistributionChart();
+            return;
+          }
+          const ctx = this.$refs.distributionCanvas.getContext('2d');
+          if (!ctx) return;
+          if (this.distributionChart) {
+            this.distributionChart.data.labels = labels;
+            this.distributionChart.data.datasets[0].data = data;
+            this.distributionChart.update();
+            return;
+          }
+          this.distributionChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+              labels,
+              datasets: [
+                {
+                  label: 'Enrollments',
+                  data,
+                  backgroundColor: '#0f172a',
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false },
+              },
+              scales: {
+                x: { ticks: { color: '#475569' } },
+                y: {
+                  ticks: { color: '#475569' },
+                  beginAtZero: true,
+                  suggestedMax: Math.max(...data, 5) + 2,
+                },
+              },
+            },
+          });
+        },
+        formatNumber(value) {
+          if (value === null || value === undefined) return '0';
+          try {
+            return new Intl.NumberFormat('en-US').format(Number(value) || 0);
+          } catch (error) {
+            return String(value);
+          }
+        },
+        formatDecimal(value) {
+          if (value === null || value === undefined || Number.isNaN(Number(value))) {
+            return '—';
+          }
+          try {
+            return Number(value).toFixed(2);
+          } catch (error) {
+            return String(value);
+          }
+        },
+        get csvDownloadUrl() {
+          const semester = (this.csvSemester || '').trim().toUpperCase();
+          if (!semester) return '/api/reports/enrollments.csv';
+          return `/api/reports/enrollments.csv?semester=${encodeURIComponent(semester)}`;
+        },
+        get csvFilename() {
+          const semester = (this.csvSemester || '').trim().toUpperCase();
+          return semester ? `enrollments_${semester}.csv` : 'enrollments.csv';
+        },
+      }));
+    });
+  </script>
+</body>
+</html>

--- a/frontend/pages/sections.html
+++ b/frontend/pages/sections.html
@@ -51,6 +51,12 @@
           </span>
           Enrollments
         </a>
+        <a href="/pages/reports.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
       </nav>
       <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
         <p>Room audit <span class="font-semibold text-slate-700">due May 3</span></p>
@@ -76,6 +82,7 @@
             <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
             <a href="/pages/sections.html" class="text-slate-900">Sections</a>
             <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="hover:text-slate-900">Reports</a>
           </nav>
         </div>
       </header>

--- a/frontend/pages/students.html
+++ b/frontend/pages/students.html
@@ -51,6 +51,12 @@
           </span>
           Enrollments
         </a>
+        <a href="/pages/reports.html" class="flex items-center gap-3 rounded-xl px-3 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M4.5 19.5 9 13.5l4.5 3 6-9" stroke-linecap="round" stroke-linejoin="round" /><path d="M3.75 5.25h16.5" stroke-linecap="round" /></svg>
+          </span>
+          Reports
+        </a>
       </nav>
       <div class="mt-auto px-6 py-6 border-t border-slate-100 text-xs text-slate-500">
         <p>Academic year <span class="font-semibold text-slate-700">2025</span></p>
@@ -76,6 +82,7 @@
             <a href="/pages/courses.html" class="hover:text-slate-900">Courses</a>
             <a href="/pages/sections.html" class="hover:text-slate-900">Sections</a>
             <a href="/pages/enrollments.html" class="hover:text-slate-900">Enrollments</a>
+            <a href="/pages/reports.html" class="hover:text-slate-900">Reports</a>
           </nav>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add a reports blueprint with GPA, course stats, and enrollment CSV aggregation endpoints plus supporting indexes
- register the reports API with the Flask app and expose MongoDB stats for the dashboard
- build the reports page UI with GPA lookup, course analytics, CSV export, and navigation links to the new module

## Testing
- python -m compileall backend